### PR TITLE
Update service metadata

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.2.0
 commit = False
 message = service version: {current_version} → {new_version}
 tag = False

--- a/.osparc/flaskapi/metadata.yml
+++ b/.osparc/flaskapi/metadata.yml
@@ -1,6 +1,6 @@
 key: simcore/services/dynamic/mmux-vite-backend
 name: MMUX Backend
-version: 1.1.0
+version: 1.2.0
 description: Python (Flask) and Dakota meta-modeling functionality in an interactive, user-friendly, guided step-by-step way
 integration-version: 2.0.0
 type: dynamic

--- a/.osparc/flaskapi/runtime.yml
+++ b/.osparc/flaskapi/runtime.yml
@@ -4,7 +4,7 @@ settings:
     value:
       Limits:
         NanoCPUs: 1000000000
-        MemoryBytes: 0
+        MemoryBytes: 2147483648 # 2GB
       Reservations:
         NanoCPUs: 1000000000
-        MemoryBytes: 0
+        MemoryBytes: 2147483648 # 2GB

--- a/.osparc/node/metadata.yml
+++ b/.osparc/node/metadata.yml
@@ -1,6 +1,6 @@
 key: simcore/services/dynamic/mmux-vite-web
 name: MMUX Frontend
-version: 1.1.0
+version: 1.2.0
 description: Vite (React + NodeJS + TypeScript) frontend for meta-modeling functionality in an interactive, user-friendly, guided step-by-step way
 integration-version: 2.0.0
 type: dynamic

--- a/.osparc/node/runtime.yml
+++ b/.osparc/node/runtime.yml
@@ -4,7 +4,7 @@ settings:
     value:
       Limits:
         NanoCPUs: 500000000
-        MemoryBytes: 0
+        MemoryBytes: 268435456 # 256MB
       Reservations:
         NanoCPUs: 500000000
-        MemoryBytes: 0
+        MemoryBytes: 268435456 # 256MB

--- a/.osparc/proxy/metadata.yml
+++ b/.osparc/proxy/metadata.yml
@@ -1,7 +1,9 @@
 key: simcore/services/dynamic/mmux-vite-app
 name: MMUX
+description: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/refs/heads/main/app/full/services/simcore_services_dynamic_mmux-vite-app.md
+icon: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/main/app/icons/s4l/simcore_services_dynamic_mmux-vite-app.png
+thumbnail: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/main/app/thumbnails/s4l/simcore_services_dynamic_mmux-vite-app.png
 version: 1.1.0
-description: meta-modeling functionality in an interactive, user-friendly, guided step-by-step way
 integration-version: 2.0.0
 type: dynamic
 authors:

--- a/.osparc/proxy/metadata.yml
+++ b/.osparc/proxy/metadata.yml
@@ -3,7 +3,7 @@ name: MMUX
 description: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/refs/heads/main/app/full/services/simcore_services_dynamic_mmux-vite-app.md
 icon: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/main/app/icons/s4l/simcore_services_dynamic_mmux-vite-app.png
 thumbnail: https://raw.githubusercontent.com/ZurichMedTech/s4l-assets/main/app/thumbnails/s4l/simcore_services_dynamic_mmux-vite-app.png
-version: 1.1.0
+version: 1.2.0
 integration-version: 2.0.0
 type: dynamic
 authors:

--- a/.osparc/proxy/runtime.yml
+++ b/.osparc/proxy/runtime.yml
@@ -7,17 +7,17 @@ settings:
     value:
       Limits:
         NanoCPUs: 500000000
-        MemoryBytes: 0
+        MemoryBytes: 268435456 # 256MB
       Reservations:
         NanoCPUs: 500000000
-        MemoryBytes: 0
+        MemoryBytes: 268435456 # 256MB
 paths-mapping:
   inputs_path: /tmp/inputs
   outputs_path: /tmp/outputs
   state_paths: []
 
 compose-spec:
-  version: '3.8'
+  version: "3.8"
   services:
     mmux-vite-backend:
       image: $${SIMCORE_REGISTRY}/simcore/services/dynamic/mmux-vite-backend:$${SERVICE_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL 				 			:= /bin/sh
 .DEFAULT_GOAL 		 			:= help
 
-DOCKER_IMAGE_TAG := 1.1.0
+DOCKER_IMAGE_TAG := 1.2.0
 
 
 FLASKAPI_DIR := ./flaskapi

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   mmux-vite-backend:
-    image: simcore/services/dynamic/mmux-vite-backend:1.1.0
+    image: simcore/services/dynamic/mmux-vite-backend:1.2.0
     environment:
       - OSPARC_API_BASE_URL=${OSPARC_API_BASE_URL}
       - OSPARC_API_KEY=${OSPARC_API_KEY}
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./flaskapi:/app
   mmux-vite-web:
-    image: simcore/services/dynamic/mmux-vite-web:1.1.0
+    image: simcore/services/dynamic/mmux-vite-web:1.2.0
     working_dir: /app
     user: "${UID:-1000}:${GID:-1000}"
     volumes:
@@ -20,7 +20,7 @@ services:
     environment:
       - NODE_ENV=development
   mmux-vite-app:
-    image: simcore/services/dynamic/mmux-vite-app:1.1.0
+    image: simcore/services/dynamic/mmux-vite-app:1.2.0
     environment:
       - WEB_SERVICE=mmux-vite-web:8080
       - BACKEND_SERVICE=mmux-vite-backend:5000

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,16 +1,16 @@
 version: "3.7"
 services:
   mmux-vite-backend:
-    image: simcore/services/dynamic/mmux-vite-backend:1.1.0
+    image: simcore/services/dynamic/mmux-vite-backend:1.2.0
     environment:
       - OSPARC_API_BASE_URL=${OSPARC_API_BASE_URL}
       - OSPARC_API_KEY=${OSPARC_API_KEY}
       - OSPARC_API_SECRET=${OSPARC_API_SECRET}
       - LOG_LEVEL=DEBUG
   mmux-vite-web:
-    image: simcore/services/dynamic/mmux-vite-web:1.1.0
+    image: simcore/services/dynamic/mmux-vite-web:1.2.0
   mmux-vite-app:
-    image: simcore/services/dynamic/mmux-vite-app:1.1.0
+    image: simcore/services/dynamic/mmux-vite-app:1.2.0
     environment:
       - WEB_SERVICE=mmux-vite-web:8080
       - BACKEND_SERVICE=mmux-vite-backend:5000


### PR DESCRIPTION
- pinned service resources on all 3 containers. total resource: 2 CPUs and 2.5 GB of ram (flask has 1 CPU and 2GB RAM)
- added thumbnail, icon and description links
I have added a placeholder icon and thumbnail and informed @drniiken about it (he might be able to provide you with an icon and a thumbnail if required)

Requires:
- https://github.com/ITISFoundation/mmux_vite/pull/69