### PR TITLE
Improve sampling campaigns UI and save config to context

### DIFF
--- a/node/src/components/GridSearchSampling.tsx
+++ b/node/src/components/GridSearchSampling.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Box, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+import { Box, Button, Skeleton, Typography } from "@mui/material";
 import { PYTHON_DAKOTA_BACKEND } from "../utils/api_objects";
 import { useMMUXContext, MMUXContextType } from "../context/MMUXContext";
 import {
@@ -12,7 +12,7 @@ import VariableConfig from "./VariableConfig";
 
 async function runGridSampling(
   context: MMUXContextType,
-  config: SamplingInputsState[]
+  config: GRIDSamplingConfig
 ) {
   const fun = context.selectedFunction as Function;
   // send config to Python backend to create LHS
@@ -41,35 +41,54 @@ async function runGridSampling(
   return jc;
 }
 
-function GridSearchSampling() {
+const GridSearchSampling = () => {
   const context = useMMUXContext();
-  const { inputVars, distribution, selectedFunction } = context;
+  const {
+    inputVars,
+    distribution,
+    selectedFunction,
+    gridSamplingConfig,
+    setGridSamplingConfig,
+  } = context;
 
-  const [gridSamplingInputs, setGridSamplingInputs] = useState<
-    SamplingInputsState[]
-  >(
-    inputVars.map((inputVar) => ({
-      variable: inputVar,
-      start: getSamplingStartValue(inputVar, distribution[selectedFunction?.uid || '']) as number,
-      end: getSamplingEndValue(inputVar, distribution[selectedFunction?.uid || '']) as number,
-      points: 10,
-    }))
-  );
+  const [gridSamplingInputs, setGridSamplingInputs] =
+    useState<GRIDSamplingConfig>(gridSamplingConfig);
+  const [loading, setLoading] = useState<boolean>(true);
 
   const handleRunSampling = async () => {
+    setGridSamplingConfig(gridSamplingInputs);
     await runGridSampling(context, gridSamplingInputs);
   };
 
   function handleInputChange(index: number, field: string, value: string) {
-    setGridSamplingInputs((prevInputs: SamplingInputsState[]) => {
+    setGridSamplingInputs((prevInputs: GRIDSamplingConfig) => {
       const newInputs = [...prevInputs];
       newInputs[index] = {
         ...newInputs[index],
-        [field]: field === "points" ? parseInt(value) : parseFloat(value),
+        [field]: parseFloat(value),
       };
       return newInputs;
     });
   }
+
+  useEffect(() => {
+    let currentSampling: GRIDSamplingConfig = gridSamplingConfig;
+    if (gridSamplingConfig.length === 0) {
+      currentSampling = inputVars.map((inputVar) => ({
+        variable: inputVar,
+        start: getSamplingStartValue(
+          inputVar,
+          distribution[selectedFunction?.uid || ""]
+        ) as number,
+        end: getSamplingEndValue(
+          inputVar,
+          distribution[selectedFunction?.uid || ""]
+        ) as number,
+      }));
+    }
+    setGridSamplingInputs(currentSampling);
+    setLoading(false);
+  }, []);
 
   return (
     <>
@@ -79,7 +98,16 @@ function GridSearchSampling() {
         fontWeight={300}
         marginBottom={1}
       >
-        Grid Sampling
+        {loading ? (
+          <Skeleton
+            variant="text"
+            width={"300px"}
+            height={"32px"}
+            sx={{ fontSize: "2rem", marginBottom: "8px" }}
+          />
+        ) : (
+          "Grid Sampling"
+        )}
       </Typography>
       <Typography
         variant="body1"
@@ -87,24 +115,51 @@ function GridSearchSampling() {
         fontWeight={200}
         marginBottom={1}
       >
-        Specify the ranges and number of points per dimension for the grid
-        search sampling.
+        {loading ? (
+          <Skeleton variant="text" width={"600px"} height={"24px"} />
+        ) : (
+          "Specify the ranges and number of points per dimension for the grid search sampling."
+        )}
       </Typography>
-      <Box sx={{
-        display: "flex",
-        flexDirection: "row",
-        flexWrap: "wrap",
-        gap: "16px",
-        marginBottom: "16px",
-        padding: "8px 0",
-      }}>
-        {gridSamplingInputs?.map((inputVar, index) => (
-          <VariableConfig index={index} inputVar={inputVar} key={index} handleInputChange={handleInputChange}/>
-        ))}
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: "16px",
+          marginBottom: "16px",
+          padding: "8px 0",
+        }}
+      >
+        {loading ? (
+          <Skeleton variant="rounded" width={"800px"} height={"232px"} />
+        ) : (
+          gridSamplingInputs?.map((inputVar, index) => (
+            <VariableConfig
+              index={index}
+              inputVar={inputVar}
+              key={index}
+              handleInputChange={handleInputChange}
+            />
+          ))
+        )}
       </Box>
-      <RunSamplingButton handleRunSampling={handleRunSampling} />
+      <Box display={"flex"} flexDirection="row" justifyContent={'space-between'} marginTop={2}>
+        <Button
+          size="small"
+          variant="contained"
+          disabled={loading}
+          onClick={() => setGridSamplingConfig(gridSamplingInputs)}
+        >
+          Save Sampling config
+        </Button>
+        <RunSamplingButton
+          disabled={loading}
+          handleRunSampling={handleRunSampling}
+        />
+      </Box>
     </>
   );
-}
+};
 
 export default GridSearchSampling;

--- a/node/src/components/LHSSampling.tsx
+++ b/node/src/components/LHSSampling.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { MMUXContextType, useMMUXContext } from "../context/MMUXContext";
 import { PYTHON_DAKOTA_BACKEND } from "../utils/api_objects";
-import { Box, Input, Typography } from "@mui/material";
+import { Box, Button, Input, Skeleton, Typography } from "@mui/material";
 import {
   Function,
   RegisteredFunctionJobCollection,
@@ -10,7 +10,10 @@ import { getSamplingStartValue, getSamplingEndValue } from "../utils/sampling";
 import { RunSamplingButton } from "./SamplingButton";
 import VariableConfig from "./VariableConfig";
 
-async function runLhsSampling(context: MMUXContextType, config: SamplingInputsState[]) {
+async function runLhsSampling(
+  context: MMUXContextType,
+  config: LHSamplingConfig
+) {
   const fun = context.selectedFunction as Function;
   // send config to Python backend to create LHS
   console.log("Running LHS Sampling with config: ", config);
@@ -19,9 +22,9 @@ async function runLhsSampling(context: MMUXContextType, config: SamplingInputsSt
     method: "POST",
     body: JSON.stringify({
       funUid: fun.uid,
-      config: config,
-      seed: config[0].seed, // TODO should be kept somewhere else in the state
-      N: config[0].points, // TODO should be kept somewhere else in the state
+      config: config.inputs,
+      seed: config.seed,
+      N: config.points,
     }),
   })
     .then(function (response) {
@@ -42,32 +45,55 @@ async function runLhsSampling(context: MMUXContextType, config: SamplingInputsSt
 
 const LHSSampling = () => {
   const context = useMMUXContext();
-  const { inputVars, distribution, selectedFunction } = useMMUXContext();
-
-  const [lhsInputs, setLhsInputs] = useState<SamplingInputsState[]>(
-    inputVars.map((inputVar) => ({
-      variable: inputVar,
-      start: getSamplingStartValue(inputVar, distribution[selectedFunction?.uid || '']) as number,
-      end: getSamplingEndValue(inputVar, distribution[selectedFunction?.uid || '']) as number,
-      points: 50, // FIXME stored here for ease of save-load as PersistentJSONState. Ideally should move somewhere else.
-      seed: 0, // FIXME stored here for ease of save-load as PersistentJSONState. Ideally should move somewhere else.
-    }))
-  );
+  const {
+    inputVars,
+    distribution,
+    selectedFunction,
+    lhsSamplingConfig,
+    setLhsSamplingConfig,
+  } = context;
+  const [lhsInputs, setLhsInputs] =
+    useState<LHSamplingConfig>(lhsSamplingConfig);
+  const [loading, setLoading] = useState<boolean>(true);
 
   const handleRunSampling = async () => {
+    setLhsSamplingConfig(lhsInputs)
     await runLhsSampling(context, lhsInputs);
   };
 
-  function handleInputChange(index: number, field: string, value: string) {
+  function handleInputChange(index: number, field: fieldType, value: string) {
     setLhsInputs((prevInputs) => {
-      const newInputs = [...prevInputs];
-      newInputs[index] = {
-        ...newInputs[index],
-        [field]: field === "points" ? parseInt(value) : parseFloat(value),
-      };
+      const newInputs: LHSamplingConfig = { ...prevInputs };
+      if(['points', 'seed'].includes(field)) {
+        newInputs[field as 'seed' | 'points'] = field === 'seed' ? parseFloat(value) : parseInt(value);
+      } else {
+        newInputs.inputs[index] = {
+          ...newInputs.inputs[index],
+          [field]: parseFloat(value),
+        };
+      }
       return newInputs;
     });
   }
+
+  useEffect(() => {
+    const currentSampling: LHSamplingConfig = lhsSamplingConfig;
+    if (lhsSamplingConfig.inputs.length === 0) {
+      currentSampling.inputs = inputVars.map((inputVar) => ({
+        variable: inputVar,
+        start: getSamplingStartValue(
+          inputVar,
+          distribution[selectedFunction?.uid || ""]
+        ) as number,
+        end: getSamplingEndValue(
+          inputVar,
+          distribution[selectedFunction?.uid || ""]
+        ) as number,
+      }));
+    }
+    setLhsInputs(currentSampling);
+    setLoading(false);
+  }, []);
 
   return (
     <>
@@ -77,7 +103,16 @@ const LHSSampling = () => {
         fontWeight={300}
         marginBottom={1}
       >
-        Latin Hypercube Sampling
+        {loading ? (
+          <Skeleton
+            variant="text"
+            width={"300px"}
+            height={"32px"}
+            sx={{ fontSize: "2rem", marginBottom: "8px" }}
+          />
+        ) : (
+          "Latin Hypercube Sampling"
+        )}
       </Typography>
       <Typography
         variant="body1"
@@ -85,47 +120,83 @@ const LHSSampling = () => {
         fontWeight={200}
         marginBottom={1}
       >
-        Specify total number of sample points that will be computed, as well as
-        the ranges of each parameter.
+        {loading ? (
+          <Skeleton variant="text" width={"600px"} height={"24px"} />
+        ) : (
+          "Specify total number of sample points that will be computed, as well as the ranges of each parameter."
+        )}
       </Typography>
-      <Box sx={{
-        display: "flex",
-        flexDirection: "row",
-        flexWrap: "wrap",
-        gap: "16px",
-        marginBottom: "16px",
-        padding: "8px 0",
-      }}>
-      {lhsInputs?.map((inputVar, index) => (
-        <VariableConfig index={index} inputVar={inputVar} key={index} handleInputChange={handleInputChange}/>
-      ))}
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: "16px",
+          marginBottom: "16px",
+          padding: "8px 0",
+        }}
+      >
+        {loading ? (
+          <Skeleton variant="rounded" width={"800px"} height={"232px"} />
+        ) : (
+          lhsInputs.inputs.map((inputVar, index) => (
+            <VariableConfig
+              index={index}
+              inputVar={inputVar}
+              key={index}
+              handleInputChange={handleInputChange}
+            />
+          ))
+        )}
       </Box>
 
-      <form style={{ display: "flex", alignItems: "center", gap: "40px" }}>
-        <Typography variant="body1">Number of sampling points: </Typography>
-        <Input
-          type="number"
-          placeholder="Number of sampling points"
-          value={lhsInputs[0].points.toString()}
-          sx={(theme) => ({
-            width: 100,
-            borderBottom: `1px solid ${theme.palette.background.paper}`,
-          })}
-          onChange={(e) => handleInputChange(0, "points", e.target.value)}
+      {loading ? (
+        <Skeleton
+          variant="rounded"
+          width={"500px"}
+          height={"28px"}
+          sx={{ fontSize: "1.5rem", marginBottom: "8px" }}
         />
-        <Typography variant="body1">Seed: </Typography>
-        <Input
-          type="number"
-          placeholder="seed"
-          value={lhsInputs[0].seed?.toString()}
-          sx={(theme) => ({
-            width: 100,
-            borderBottom: `1px solid ${theme.palette.background.paper}`,
-          })}
-          onChange={(e) => handleInputChange(0, "seed", e.target.value)}
+      ) : (
+        <form style={{ display: "flex", alignItems: "center", gap: "40px" }}>
+          <Typography variant="body1">Number of sampling points: </Typography>
+          <Input
+            type="number"
+            placeholder="Number of sampling points"
+            value={lhsInputs.points.toString()}
+            sx={(theme) => ({
+              width: 100,
+              borderBottom: `1px solid ${theme.palette.background.paper}`,
+            })}
+            onChange={(e) => handleInputChange(0, "points", e.target.value)}
+          />
+          <Typography variant="body1">Seed: </Typography>
+          <Input
+            type="number"
+            placeholder="seed"
+            value={lhsInputs.seed.toString()}
+            sx={(theme) => ({
+              width: 100,
+              borderBottom: `1px solid ${theme.palette.background.paper}`,
+            })}
+            onChange={(e) => handleInputChange(0, "seed", e.target.value)}
+          />
+        </form>
+      )}
+      <Box display={"flex"} flexDirection="row" justifyContent={'space-between'} marginTop={2}>
+        <Button
+          size="small"
+          variant="contained"
+          disabled={loading}
+          onClick={() => setLhsSamplingConfig(lhsInputs)}
+        >
+          Save Sampling config
+        </Button>
+        <RunSamplingButton
+          disabled={loading}
+          handleRunSampling={handleRunSampling}
         />
-      </form>
-      <RunSamplingButton handleRunSampling={handleRunSampling} />
+      </Box>
     </>
   );
 };

--- a/node/src/components/RunSingleJob.tsx
+++ b/node/src/components/RunSingleJob.tsx
@@ -1,16 +1,16 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PYTHON_DAKOTA_BACKEND } from "../utils/api_objects";
-import { Box, Typography } from "@mui/material";
+import { Box, Button, Skeleton, Typography } from "@mui/material";
 import { Function, FunctionJob } from "../osparc-api-ts-client";
 import { useMMUXContext, MMUXContextType } from "../context/MMUXContext";
 import { RunSamplingButton } from "./SamplingButton";
 import ValueConfig from "./ValueConfig";
 
-async function runTestJob(context: MMUXContextType | undefined, config: SamplingInputsState[]) {
+async function runTestJob(context: MMUXContextType, config: SingleJobConfig[]) {
   const fun = context?.selectedFunction as Function;
   // send config to Python backend to create LHS
   console.log("Running single job with config: ", config);
-  context?.setLaunchingSampling(true);
+  context.setLaunchingSampling(true);
   const j = await fetch(PYTHON_DAKOTA_BACKEND + "/flask/test_job", {
     method: "POST",
     body: JSON.stringify({
@@ -28,30 +28,20 @@ async function runTestJob(context: MMUXContextType | undefined, config: Sampling
     .catch(function (error) {
       console.error("Error running single job: ", error);
     });
-  context?.setLaunchingSampling(false);
+  context.setLaunchingSampling(false);
   return j;
 }
 
 const TestJob = () => {
   const context = useMMUXContext();
-  const { inputVars } = context;
-  const [jobInputs, setJobInputs] = useState<Array<SamplingInputsState>>(
-    inputVars.map((inputVar) => ({
-      variable: inputVar,
-      value: 0.0,
-      start: 0.0, // Not used in this case, but kept for consistency
-      end: 1.0, // Not used in this case, but kept for consistency
-      points: 1, // Not used in this case, but kept for consistency
-      seed: 0, // Not used in this case, but kept for consistency
-    }))
-  );
+  const { inputVars, singleJobConfig, setSingleJobConfig } = context;
+  const [jobInputs, setJobInputs] =
+    useState<Array<SingleJobConfig>>(singleJobConfig);
+  const [loading, setLoading] = useState<boolean>(true);
 
-  const handleRunSampling = () => {
-    runTestJob(context, jobInputs);
-    setTimeout(() => {
-      context?.setLaunchingSampling(false);
-    }, 1000);
-    // TODO have some way to detect that it finished running; and set the corresponding context variable to False
+  const handleRunSampling = async () => {
+    setSingleJobConfig(jobInputs);
+    await runTestJob(context, jobInputs);
   };
 
   function handleInputChange(index: number, field: string, value: string) {
@@ -59,13 +49,23 @@ const TestJob = () => {
       const newInputs = [...prevInputs];
       newInputs[index] = {
         ...newInputs[index],
-        [field]: field === "points" ? parseInt(value) : parseFloat(value),
+        [field]: parseFloat(value),
       };
       return newInputs;
     });
   }
 
-  console.log("TestJob inputs: ", jobInputs);
+  useEffect(() => {
+    let currentSampling: SingleJobConfig[] = singleJobConfig;
+    if (currentSampling.length === 0) {
+      currentSampling = inputVars.map((inputVar) => ({
+        variable: inputVar,
+        value: 0.0,
+      }));
+    }
+    setJobInputs(currentSampling);
+    setLoading(false);
+  }, [inputVars, singleJobConfig]);
 
   return (
     <>
@@ -75,7 +75,16 @@ const TestJob = () => {
         fontWeight={300}
         marginBottom={1}
       >
-        Single Test Run
+        {loading ? (
+          <Skeleton
+            variant="text"
+            width={"300px"}
+            height={"32px"}
+            sx={{ fontSize: "2rem", marginBottom: "8px" }}
+          />
+        ) : (
+          "Single Test Run"
+        )}
       </Typography>
       <Typography
         variant="body1"
@@ -83,21 +92,48 @@ const TestJob = () => {
         fontWeight={200}
         marginBottom={1}
       >
-        Run a single parameter combination
+        {loading ? (
+          <Skeleton variant="text" width={"600px"} height={"24px"} />
+        ) : (
+          "Run a single parameter combination"
+        )}
       </Typography>
-      <Box sx={{
-        display: "flex",
-        flexDirection: "row",
-        flexWrap: "wrap",
-        gap: "16px",
-        marginBottom: "16px",
-        padding: "8px 0",
-      }}>
-        {jobInputs?.map((inputVar, index) => (
-          <ValueConfig index={index} inputVar={inputVar} handleInputChange={handleInputChange} />
-        ))}
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "row",
+          flexWrap: "wrap",
+          gap: "16px",
+          marginBottom: "16px",
+          padding: "8px 0",
+        }}
+      >
+        {loading ? (
+          <Skeleton variant="rounded" width={"800px"} height={"232px"} />
+        ) : (
+          jobInputs?.map((inputVar, index) => (
+            <ValueConfig
+              index={index}
+              inputVar={inputVar}
+              handleInputChange={handleInputChange}
+            />
+          ))
+        )}
       </Box>
-      <RunSamplingButton handleRunSampling={handleRunSampling}/>
+      <Box display={"flex"} flexDirection="row" justifyContent={'space-between'} marginTop={2}>
+        <Button
+          size="small"
+          variant="contained"
+          disabled={loading}
+          onClick={() => setSingleJobConfig(jobInputs)}
+        >
+          Save Sampling config
+        </Button>
+        <RunSamplingButton
+          disabled={loading}
+          handleRunSampling={handleRunSampling}
+        />
+      </Box>
     </>
   );
 };

--- a/node/src/components/SamplingButton.tsx
+++ b/node/src/components/SamplingButton.tsx
@@ -1,31 +1,32 @@
-import { Box, Button } from '@mui/material';
-import { useMMUXContext } from '../context/MMUXContext';
+import { Button, CircularProgress } from "@mui/material";
+import { useMMUXContext } from "../context/MMUXContext";
 
 type RunSamplingButtonProps = {
   handleRunSampling: () => void;
+  disabled?: boolean;
 };
 
 export const RunSamplingButton = (props: RunSamplingButtonProps) => {
-    const { handleRunSampling } = props;
-    const context = useMMUXContext();
-    const { launchingSampling, runningSampling } = context;
+  const { handleRunSampling, disabled } = props;
+  const { launchingSampling, runningSampling } = useMMUXContext();
 
-    return (
-      <Box sx={{ display: "flex", alignItems: "center", gap: "8px", marginTop: '16px' }}>
-        {/* <Button variant="contained" onClick={() => }>Run LHS Sampling</Button> */}
-
-        <Button
-          variant="contained"
-          onClick={handleRunSampling}
-          disabled={launchingSampling || runningSampling}
-        >
-          {launchingSampling
-            ? "Launching..."
-            : runningSampling
-            ? "Running..."
-            : "Run Sampling"}
-        </Button>
-        {launchingSampling && <Box className="spinner" />}
-      </Box>
-    );
-  }
+  return (
+    <>
+      <Button
+        variant="contained"
+        onClick={handleRunSampling}
+        disabled={launchingSampling || runningSampling || disabled}
+      >
+        {launchingSampling ? (
+          <>
+            Launching... <CircularProgress size={"0.875rem"} />
+          </>
+        ) : runningSampling ? (
+          "Running..."
+        ) : (
+          "Run Sampling"
+        )}
+      </Button>
+    </>
+  );
+};

--- a/node/src/components/ValueConfig.tsx
+++ b/node/src/components/ValueConfig.tsx
@@ -6,7 +6,7 @@ const VariableConfig = ({
   index,
   handleInputChange,
 }: {
-  inputVar: SamplingInputsState;
+  inputVar: SingleJobConfig;
   index: number;
   handleInputChange: (index: number, field: string, value: string) => void;
 }) => {

--- a/node/src/components/VariableConfig.tsx
+++ b/node/src/components/VariableConfig.tsx
@@ -1,16 +1,15 @@
 import { Box, Typography, Chip, useTheme } from "@mui/material";
 import { InputBlock } from "./InputBlock";
 
-const VariableConfig = ({
-  inputVar,
-  index,
-  handleInputChange,
-}: {
+interface VariableConfigProps {
   inputVar: SamplingInputsState;
   index: number;
-  handleInputChange: (index: number, field: string, value: string) => void;
-}) => {
+  handleInputChange: (index: number, field: fieldType, value: string) => void;
+}
+
+const VariableConfig = (props: VariableConfigProps) => {
   const theme = useTheme();
+  const { inputVar, index, handleInputChange } = props;
 
   return (
     <Box
@@ -43,7 +42,6 @@ const VariableConfig = ({
       </Typography>
       <InputBlock
         name="Start"
-        type="text"
         value={inputVar.start}
         onChange={(n) => handleInputChange(index, "start", n as string)}
       />

--- a/node/src/context/MMUXContext.tsx
+++ b/node/src/context/MMUXContext.tsx
@@ -8,8 +8,8 @@ import {
 export interface MMUXContextType {
   selectedFunction: Function | undefined;
   setSelectedFunction: (F: Function | undefined) => void;
-  distribution: {[key: string]:InputVarSelection};
-  setDistribution: (d: {[key: string]:InputVarSelection}) => void;
+  distribution: { [key: string]: InputVarSelection };
+  setDistribution: (d: { [key: string]: InputVarSelection }) => void;
   inputVars: string[];
   setInputVars: (vars: string[]) => void;
   outputVars: string[] | undefined;
@@ -20,8 +20,14 @@ export interface MMUXContextType {
   setLaunchingSampling: (b: boolean) => void;
   runningSampling: boolean;
   setRunningSampling: (b: boolean) => void;
-  numSamples: {[key: string]:number};
-  setNumSamples: (ns: {[key: string]:number}) => void;
+  lhsSamplingConfig: LHSamplingConfig;
+  setLhsSamplingConfig: (config: LHSamplingConfig) => void;
+  gridSamplingConfig: GRIDSamplingConfig;
+  setGridSamplingConfig: (config: GRIDSamplingConfig) => void;
+  singleJobConfig: SingleJobConfig[];
+  setSingleJobConfig: (config: SingleJobConfig[]) => void;
+  numSamples: { [key: string]: number };
+  setNumSamples: (ns: { [key: string]: number }) => void;
   runningJobCollection: RegisteredFunctionJobCollection | undefined;
   setRunningJobCollection: (
     jc: RegisteredFunctionJobCollection | undefined
@@ -45,26 +51,48 @@ type Props = {
   children: React.ReactNode;
 };
 
+const defaultLHSamplingConfig: LHSamplingConfig = {
+  inputs: [],
+  points: 50,
+  seed: 0,
+};
+
+const defaultGRIDamplingConfig: GRIDSamplingConfig = [];
+
+const defaultSingleJobConfig: SingleJobConfig[] = [];
+
 export const MMUXContextProvider = ({ children }: Props) => {
   const [currentView, setCurrentView] = useState(0);
   const [funct, setFunct] = useState<Function | undefined>(undefined);
   const [launchingSampling, setLaunchingSampling] = useState<boolean>(false);
   const [runningSampling, setRunningSampling] = useState<boolean>(false);
+  const [lhsSamplingConfig, setLhsSamplingConfig] = useState<LHSamplingConfig>(
+    defaultLHSamplingConfig
+  );
+  const [gridSamplingConfig, setGridSamplingConfig] =
+    useState<GRIDSamplingConfig>(defaultGRIDamplingConfig);
+  const [singleJobConfig, setSingleJobConfig] = useState<SingleJobConfig[]>(
+    defaultSingleJobConfig
+  );
   const [selectedJobUids, setSelectedJobUids] = useState<Array<string>>([]);
   const [fetchedJobCollections, setFetchedJobCollections] = useState<
     SelectedJobCollection[]
   >([]);
   const [inputVars, setInputVars] = useState<string[]>([]);
-  const [distribution, setDistribution] = useState<{[key: string]:InputVarSelection}>({});
-  const [numSamples, setNumSamples] = useState<{[key: string]:number}>({});
+  const [distribution, setDistribution] = useState<{
+    [key: string]: InputVarSelection;
+  }>({});
+  const [numSamples, setNumSamples] = useState<{ [key: string]: number }>({});
   const [outputVars, setOutputVars] = useState<string[] | undefined>(undefined);
   const [selectedQoI, setSelectedQoI] = useState<string | undefined>(undefined);
-  const [runningJobCollection, setRunningJobCollection] = useState<RegisteredFunctionJobCollection | undefined>(undefined);
+  const [runningJobCollection, setRunningJobCollection] = useState<
+    RegisteredFunctionJobCollection | undefined
+  >(undefined);
   const [isSuMoGenerated, setIsSuMoGenerated] = useState<boolean>(false);
 
   const handleSelecedFunction = (F: Function | undefined) => {
     setFunct(F);
-    setSelectedJobUids([])
+    setSelectedJobUids([]);
     setFetchedJobCollections([]);
   };
 
@@ -91,6 +119,12 @@ export const MMUXContextProvider = ({ children }: Props) => {
       setCurrentView: setCurrentView,
       launchingSampling: launchingSampling,
       setLaunchingSampling: setLaunchingSampling,
+      lhsSamplingConfig: lhsSamplingConfig,
+      setLhsSamplingConfig: setLhsSamplingConfig,
+      gridSamplingConfig: gridSamplingConfig,
+      setGridSamplingConfig: setGridSamplingConfig,
+      singleJobConfig: singleJobConfig,
+      setSingleJobConfig: setSingleJobConfig,
       runningSampling: runningSampling,
       setRunningSampling: setRunningSampling,
       numSamples: numSamples,
@@ -105,9 +139,26 @@ export const MMUXContextProvider = ({ children }: Props) => {
       setSelectedJobUids: setSelectedJobUids,
       filterSelectedJobList: filterSelectedJobList,
       isSuMoGenerated: isSuMoGenerated,
-      setIsSuMoGenerated: setIsSuMoGenerated
+      setIsSuMoGenerated: setIsSuMoGenerated,
     };
-  }, [funct, distribution, inputVars, outputVars, currentView, launchingSampling, runningSampling, numSamples, selectedQoI, runningJobCollection, fetchedJobCollections, selectedJobUids, isSuMoGenerated]);
+  }, [
+    funct,
+    distribution,
+    inputVars,
+    outputVars,
+    currentView,
+    launchingSampling,
+    lhsSamplingConfig,
+    gridSamplingConfig,
+    singleJobConfig,
+    runningSampling,
+    numSamples,
+    selectedQoI,
+    runningJobCollection,
+    fetchedJobCollections,
+    selectedJobUids,
+    isSuMoGenerated,
+  ]);
   return (
     <MMUXContext.Provider value={memoState}>{children}</MMUXContext.Provider>
   );

--- a/node/src/global.d.ts
+++ b/node/src/global.d.ts
@@ -7,10 +7,22 @@ type SamplingInputsState = {
   variable: string;
   start: number;
   end: number;
-  value?: number; // FIXME stored here for ease of save-load as PersistentJSONState. Ideally should move somewhere else.
-  points: number; // FIXME stored here for ease of save-load as PersistentJSONState. Ideally should move somewhere else.
-  seed?: number; // FIXME stored here for ease of save-load as PersistentJSONState. Ideally should move somewhere else.
 }
+
+type SingleJobConfig = {
+  variable: string;
+  value: number;
+}
+
+type fieldType = "start" | "end" | "points" | "seed";
+
+type LHSamplingConfig = {
+  inputs: SamplingInputsState[];
+  points: number;
+  seed: number;
+}
+
+type GRIDSamplingConfig = SamplingInputsState[];
 
 type dataUQHistogramType = {
   bins_start: number;
@@ -18,7 +30,7 @@ type dataUQHistogramType = {
   bin_means: number[];
   bin_stds: number[];
   q1: number;
-  median: number; 
+  median: number;
   q3: number;
   whisker_min: number;
   whisker_max: number;


### PR DESCRIPTION
Changes made
- Context now holds the config values, the changes will be saved in the context when pressing the save config button and also when the sampling campaign is run.
- Added loading state and used skeleton components to have a placeholder for the elements, so that no strange resizes happen due to the loading status
- Pushed the same logic to the 3 sampling methods