### PR TITLE
Work/jgo/fixing node project id for local campaign launching

### DIFF
--- a/.osparc/proxy-sumo-read/runtime.yml
+++ b/.osparc/proxy-sumo-read/runtime.yml
@@ -24,6 +24,7 @@ compose-spec:
       environment:
         - SERVICE_MODE=SUMO
         - PERMISSIONS=READ-ONLY
+        - DEPLOYMENT_MODE=OSPARC
     mmux-vite-web:
       image: $${SIMCORE_REGISTRY}/simcore/services/dynamic/mmux-vite-web:$${SERVICE_VERSION}
 

--- a/.osparc/proxy-sumo-write/runtime.yml
+++ b/.osparc/proxy-sumo-write/runtime.yml
@@ -24,6 +24,7 @@ compose-spec:
       environment:
         - SERVICE_MODE=SUMO
         - PERMISSIONS=WRITE
+        - DEPLOYMENT_MODE=OSPARC
     mmux-vite-web:
       image: $${SIMCORE_REGISTRY}/simcore/services/dynamic/mmux-vite-web:$${SERVICE_VERSION}
 

--- a/.osparc/proxy-uq-read/runtime.yml
+++ b/.osparc/proxy-uq-read/runtime.yml
@@ -24,6 +24,7 @@ compose-spec:
       environment:
         - SERVICE_MODE=UQ
         - PERMISSIONS=READ-ONLY
+        - DEPLOYMENT_MODE=OSPARC
     mmux-vite-web:
       image: $${SIMCORE_REGISTRY}/simcore/services/dynamic/mmux-vite-web:$${SERVICE_VERSION}
 

--- a/.osparc/proxy-uq-write/runtime.yml
+++ b/.osparc/proxy-uq-write/runtime.yml
@@ -24,6 +24,7 @@ compose-spec:
       environment:
         - SERVICE_MODE=UQ
         - PERMISSIONS=WRITE
+        - DEPLOYMENT_MODE=OSPARC
     mmux-vite-web:
       image: $${SIMCORE_REGISTRY}/simcore/services/dynamic/mmux-vite-web:$${SERVICE_VERSION}
 

--- a/Makefile
+++ b/Makefile
@@ -97,13 +97,15 @@ build-no-cache: compose-spec ## build docker images
 run-develop-sumo-read: ## runs for development SUMO/READ-ONLY
 	export SERVICE_MODE=SUMO && \
 	export PERMISSIONS=READ-ONLY && \
+	export DEPLOYMENT_MODE=LOCAL && \
 	export APP_IMAGE=mmux-vite-app-sumo-read && \
 	docker compose --file docker-compose-development.yml up
 
 .PHONY: run-develop-sumo-write
 run-develop-sumo-write: ## runs for development SUMO/WRITE
-	export SERVICE_MODE=SUMO \
-	&& export PERMISSIONS=WRITE && \
+	export SERVICE_MODE=SUMO && \
+	export PERMISSIONS=WRITE && \
+	export DEPLOYMENT_MODE=LOCAL && \
 	export APP_IMAGE=mmux-vite-app-sumo-write && \
 	docker compose --file docker-compose-development.yml up
 
@@ -111,6 +113,7 @@ run-develop-sumo-write: ## runs for development SUMO/WRITE
 run-develop-uq-read: ## runs for development UQ/READ-ONLY
 	export SERVICE_MODE=UQ && \
 	export PERMISSIONS=READ-ONLY && \
+	export DEPLOYMENT_MODE=LOCAL && \
 	export APP_IMAGE=mmux-vite-app-uq-read && \
 	docker compose --file docker-compose-development.yml up
 
@@ -118,6 +121,7 @@ run-develop-uq-read: ## runs for development UQ/READ-ONLY
 run-develop-uq-write: ## runs for development UQ/WRITE
 	export SERVICE_MODE=UQ && \
 	export PERMISSIONS=WRITE && \
+	export DEPLOYMENT_MODE=LOCAL && \
 	export APP_IMAGE=mmux-vite-app-uq-write && \
 	docker compose --file docker-compose-development.yml up
 
@@ -127,6 +131,7 @@ run-develop-uq-write: ## runs for development UQ/WRITE
 run-prod-local-sumo-read: ## runs for validation as it would be in production SUMO/READ-ONLY
 	export SERVICE_MODE=SUMO && \
 	export PERMISSIONS=READ-ONLY && \
+	export DEPLOYMENT_MODE=LOCAL && \
 	export APP_IMAGE=mmux-vite-app-sumo-read && \
 	docker compose --file docker-compose-local.yml up
 
@@ -134,6 +139,7 @@ run-prod-local-sumo-read: ## runs for validation as it would be in production SU
 run-prod-local-sumo-write: ## runs for validation as it would be in production SUMO/WRITE
 	export SERVICE_MODE=SUMO && \
 	export PERMISSIONS=WRITE && \
+	export DEPLOYMENT_MODE=LOCAL && \
 	export APP_IMAGE=mmux-vite-app-sumo-write && \
 	docker compose --file docker-compose-local.yml up
 
@@ -141,6 +147,7 @@ run-prod-local-sumo-write: ## runs for validation as it would be in production S
 run-prod-local-uq-read: ## runs for validation as it would be in production UQ/READ-ONLY
 	export SERVICE_MODE=UQ && \
 	export PERMISSIONS=READ-ONLY && \
+	export DEPLOYMENT_MODE=LOCAL && \
 	export APP_IMAGE=mmux-vite-app-uq-read && \
 	docker compose --file docker-compose-local.yml up
 
@@ -148,6 +155,7 @@ run-prod-local-uq-read: ## runs for validation as it would be in production UQ/R
 run-prod-local-uq-write: ## runs for validation as it would be in production UQ/WRITE
 	export SERVICE_MODE=UQ && \
 	export PERMISSIONS=WRITE && \
+	export DEPLOYMENT_MODE=LOCAL && \
 	export APP_IMAGE=mmux-vite-app-uq-write && \
 	docker compose --file docker-compose-local.yml up
 

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -10,6 +10,7 @@ services:
       - DEVELOPMENT_MODE=true
       - SERVICE_MODE=${SERVICE_MODE}
       - PERMISSIONS=${PERMISSIONS}
+      - DEPLOYMENT_MODE=${DEPLOYMENT_MODE}
     volumes:
       - ./flaskapi:/app
   mmux-vite-web:

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -9,6 +9,7 @@ services:
       - LOG_LEVEL=DEBUG
       - SERVICE_MODE=${SERVICE_MODE}
       - PERMISSIONS=${PERMISSIONS}
+      - DEPLOYMENT_MODE=${DEPLOYMENT_MODE}
   mmux-vite-web:
     image: simcore/services/dynamic/mmux-vite-web:1.3.0
   mmux-vite-app:

--- a/flaskapi/flask_workflows.py
+++ b/flaskapi/flask_workflows.py
@@ -687,15 +687,13 @@ class ParentInfo(NamedTuple):
     parent_project_id: str
     
 def _get_parent_ids() -> ParentInfo:
-    _logger.info("env vars: ", [os.environ.get(key) for key in os.environ.keys()])
-    _logger.info("env vars keys: ", [key for key in os.environ.keys()])
     deployment_mode = _deployment_mode()
     if deployment_mode == "LOCAL":
-        parent_node_id = "a" * 32
-        parent_project_id = "a" * 32
+        parent_node_id = "null"
+        parent_project_id = "null"
     elif deployment_mode == "OSPARC":
-        parent_node_id = os.environ.get("OSPARC_NODE_ID", "a" * 32)
-        parent_project_id = os.environ.get("OSPARC_STUDY_ID", "a" * 32)
+        parent_node_id = os.environ.get("OSPARC_NODE_ID", None)
+        parent_project_id = os.environ.get("OSPARC_STUDY_ID", None)
         if not parent_node_id or not parent_project_id:
             _logger.error("OSPARC_NODE_ID or OSPARC_STUDY_ID environment variables are not set. Cannot create a sampling campaign through map function.")
             raise ValueError("OSPARC_NODE_ID or OSPARC_STUDY_ID environment variables are not set.")
@@ -833,15 +831,21 @@ def flask_clone_job():
         # Convert request data into a Python dictionary
         request_data: dict = json.loads(request.data.decode("utf-8"))
         project_job_id = request_data["projectJobId"]
-    
+        function_name = request_data["functionName"]
+        inputs: dict = request_data["projectInputs"]
+        
         # Clone the job using the job_id
-        study_data = BodyCloneStudyV0StudiesStudyIdClonePost(title="...", description="...")
-        parent_info = _get_parent_ids()
+        def format_inputs_for_description(inputs: dict) -> str:
+            """Formats a dictionary of inputs into a human-readable string for description."""
+            formatted_inputs = "\n- ".join([""]+[f"*{key}*: {float(value):.4g}" for key, value in inputs.items()])
+            return f"#### Inputs:\n\n{formatted_inputs}"
+
+        formatted_inputs = format_inputs_for_description(inputs)
+        study_data = BodyCloneStudyV0StudiesStudyIdClonePost(title="Job " + function_name, 
+                                     description=f"Clone of job *{project_job_id}* from function *{function_name}*.\n\n{formatted_inputs}",)
+        _logger.debug("Study data: ", study_data)
         study = studies_api_instance.clone_study(project_job_id, hidden=False,
-                                                 body_clone_study_v0_studies_study_id_clone_post=study_data,
-                                                 x_simcore_parent_node_id=parent_info.parent_node_id, 
-                                                 x_simcore_parent_project_uuid=parent_info.parent_project_id) 
-        # studies_api_instance.patch_study(study)  # this will update the study with the new data -- FIXME this endpoint needs to be exposed in the API
+                                                 body_clone_study_v0_studies_study_id_clone_post=study_data,)
         _logger.debug(f"Cloned study: {study.to_dict()}")
         _logger.debug("Done!!")
         return jsonify(study.to_dict())

--- a/flaskapi/flask_workflows.py
+++ b/flaskapi/flask_workflows.py
@@ -1,17 +1,3 @@
-"""TODOs
-- implement other metrics of SuMo assessment (can do wo internet)
-*** need to find where I have those codes (download some other repos!)
-DONE - implement a mock function 
-& LHS running (can do wo internet) in Setup screen
-- implement Running visualization (based on ParallelRunner GUI)
-
-- implement MUI table w dropdowns to select Jobs in SuMo screen (NEED Copilot)
-- implement UQ (better w Copilot, to do the pop-up to define the distribution, params, etc of each input variable).
-- implement report generation --  later, check w Melanie & Reboux
-
-FIXME crashing error when I already have SuMo plots open & went back to setup & choose Sinc Python function
-"""
-
 import re
 import os
 from pathlib import Path
@@ -52,9 +38,6 @@ flask_logger.propagate = True
 # Same for Werkzeug (Flask's underlying WSGI library)
 werkzeug_logger = logging.getLogger("werkzeug")
 werkzeug_logger.propagate = True
-
-
-
 _logger.info("Logging started")
 #############################################################
 
@@ -160,11 +143,22 @@ def permissions():
     """Used to check the environment variable PERMISSIONS."""
     try:
         permissions = os.environ["PERMISSIONS"]
-        _logger.info(f"Service mode: {permissions}")
+        _logger.info(f"permissions: {permissions}")
         return jsonify({"permissions": permissions}), 200
     except KeyError:
-        _logger.error("PERMISSIOSN environment variable is not set.")
+        _logger.error("PERMISSIONS environment variable is not set.")
         return jsonify({"error": "PERMISSIONS environment variable is not set."}), 500
+    
+def _deployment_mode() -> str:
+    """Used to check the environment variable DEPLOYMENT_MODE. 
+    Will only be used within the backend (in principle), so no need to expose an endpoint (for now)."""
+    try:
+        deployment_mode = os.environ["DEPLOYMENT_MODE"]
+        _logger.info(f"deployment mode: {deployment_mode}")
+        return deployment_mode
+    except KeyError:
+        _logger.error("DEPLOYMENT_MODE environment variable is not set.")
+        raise ValueError("DEPLOYMENT_MODE environment variable is not set.")
 
 def _get_all_items(api_call: Callable, *args, **kwargs):
     """Helper function to get all items from a paginated API call."""
@@ -520,7 +514,7 @@ def flask_manual_uq_propagation_with_uncertainty():
         ## now, use the prediction of std_hat to get an estimation of the uncertainty over the UQ
         assert output_response + "_std_hat" in results, f"Cannot perform uncertainty of UQ if there is no prediction of the uncertainty"
         
-        ## TODO change by normal sampling
+        ## TODO change by normal (gaussian) sampling
         from scipy.special import erfinv
         all_results = np.empty(shape=(n_histograms, num_samples), dtype=float) # create an empty array to store the results
         for i in range(n_histograms):
@@ -656,57 +650,7 @@ def flask_sumo_grid_evaluation():
     except Exception as e:
         _logger.error(f"Error during grid evaluation: {e}")
         abort(make_response(jsonify({"error": str(e)}), 500))
-
-@app.route("/flask/uq_propagation", methods=["POST"])
-def flask_uq_propagation():
-    os.chdir(Path(__file__).parent)
-    _logger.debug("Starting flask function: flask_uq_propagation")
-    _logger.debug("Cwd: " + str(Path.cwd()))
-
-    try:
-        # Convert request data into a Python dictionary
-        request_data: dict = json.loads(request.data.decode("utf-8"))
-        input_vars: List[str] = request_data["inputVars"]
-        output_response = request_data["output"]
-        num_samples: int = request_data["numSamples"]
-        ######### TODO make this more generic, not only for normal distribution
-        means: Dict[str, float] = request_data["means"]
-        stds: Dict[str, float] = request_data["stds"]
-        ####################################################################
-        make_log: bool = request_data.get("log", False)
-        jobs: List[FunctionJob] = request_data["FunctionJobs"]
-
-        TRAINING_FILE = _create_training_file_from_jobs(jobs, input_vars, output_response)
-        run_dir = TRAINING_FILE.parent
-
-        PROCESSED_TRAINING_FILE = process_input_file(
-            TRAINING_FILE,
-            make_log=make_log,
-            columns_to_keep=input_vars + [output_response], # type: ignore
-        )
-
-
-        if make_log:  # FIXME for now log applies to all inputs & the output
-            input_vars = [f"log_{var}" for var in input_vars]
-            output_response = f"log_{output_response}"
-            means = {f"log_{key}": np.log(val) for key, val in means.items()}
-            stds = {f"log_{key}": np.log(val) for key, val in stds.items()}
-
-        samples = propagate_uq(
-            run_dir,
-            PROCESSED_TRAINING_FILE,
-            input_vars,
-            output_response,
-            ## TODO make distributions other than normal functional!!
-            means,
-            stds,
-            n_samples=num_samples,
-        )
-
-        return jsonify(samples)
-    except Exception as e:
-        _logger.error(f"Error during UQ propagation: {e}")
-        abort(make_response(jsonify({"error": str(e)}), 500)) 
+        
 
 @app.route("/flask/test_job", methods=["POST"])
 def flask_test_job():
@@ -722,7 +666,6 @@ def flask_test_job():
         _logger.debug(f"Config: {config}")
         sample = {config[i]["variable"]: config[i]["value"] for i in range(len(config))} 
 
-        ## DEBUGGING
         _logger.debug("Input to validate_function_inputs: %s" , sample)
         val = functions_api_instance.validate_function_inputs(function_uid, sample)  # this is working - changing the name of the variable does return a validation error
         _logger.debug(f"Validated function inputs for function {function_uid} with sample {sample}: {val}")
@@ -734,17 +677,6 @@ def flask_test_job():
         _logger.debug(f"Job UID: {uid}")
         job = _get_function_job_from_uid(uid)
         _logger.debug(f"Created job: {job}")
-        # while status.status not in ("SUCCESS", "FAILED"):
-        #     _logger.info(f"Job {job['uid']} is still running, status: {status.status}")
-        #     status = job_api_instance.function_job_status(job["uid"])
-        # if status.status != "SUCCESS":
-        #     _logger.error(f"Job {job['uid']} did not complete successfully. Status: {status.status}")
-        #     return jsonify({"error": f"Job {job['uid']} did not complete successfully. Status: {status.status}"})
-        # else:
-        #     outputs = job_api_instance.function_job_outputs(job["uid"])
-        #     _logger.info(f"Job {job['uid']} completed successfully. Outputs: {outputs}")
-        #     job["outputs"] = outputs.to_dict()  # type: ignore
-        ###
         return jsonify(job)  # return the job details as a dictionary
     except Exception as e:
         _logger.error(f"Error while testing job for function {function_uid} with config {config}: {e}")
@@ -755,11 +687,21 @@ class ParentInfo(NamedTuple):
     parent_project_id: str
     
 def _get_parent_ids() -> ParentInfo:
-    parent_node_id = os.environ.get("OSPARC_NODE_ID", None)
-    parent_project_id = os.environ.get("OSPARC_STUDY_ID", None)
-    if not parent_node_id or not parent_project_id:
-        _logger.error("OSPARC_NODE_ID or OSPARC_STUDY_ID environment variables are not set. Cannot create a sampling campaign through map function.")
-        abort(make_response(jsonify({"error": "OSPARC_NODE_ID or OSPARC_STUDY_ID environment variables are not set."}), 500))
+    _logger.info("env vars: ", [os.environ.get(key) for key in os.environ.keys()])
+    _logger.info("env vars keys: ", [key for key in os.environ.keys()])
+    deployment_mode = _deployment_mode()
+    if deployment_mode == "LOCAL":
+        parent_node_id = "a" * 32
+        parent_project_id = "a" * 32
+    elif deployment_mode == "OSPARC":
+        parent_node_id = os.environ.get("OSPARC_NODE_ID", "a" * 32)
+        parent_project_id = os.environ.get("OSPARC_STUDY_ID", "a" * 32)
+        if not parent_node_id or not parent_project_id:
+            _logger.error("OSPARC_NODE_ID or OSPARC_STUDY_ID environment variables are not set. Cannot create a sampling campaign through map function.")
+            raise ValueError("OSPARC_NODE_ID or OSPARC_STUDY_ID environment variables are not set.")
+    else:
+        _logger.error(f"Unknown value of DEPLOYMENT_MODE env variable ({deployment_mode}). Thus not able to fetch parent node and project IDs.")
+        raise ValueError(f"DEPLOYMENT_MODE env variable could not be recognized ({deployment_mode}) - can not run new pipelines as there would be no billing information.")
     return ParentInfo(parent_node_id=parent_node_id, parent_project_id=parent_project_id)
 
 def _run_sampling_map(function_uid, samples):

--- a/flaskapi/flask_workflows.py
+++ b/flaskapi/flask_workflows.py
@@ -669,7 +669,10 @@ def flask_test_job():
         _logger.debug("Input to validate_function_inputs: %s" , sample)
         val = functions_api_instance.validate_function_inputs(function_uid, sample)  # this is working - changing the name of the variable does return a validation error
         _logger.debug(f"Validated function inputs for function {function_uid} with sample {sample}: {val}")
-        response = functions_api_instance.run_function(function_uid, sample) # type: ignore
+        parent_info = _get_parent_ids()
+        response = functions_api_instance.run_function(function_uid, body=sample,
+                                                       x_simcore_parent_node_id=parent_info.parent_node_id,
+                                                       x_simcore_parent_project_uuid=parent_info.parent_project_id)
         _logger.debug(f"Response from run_function with sample {sample}: {response}")
         assert hasattr(response, "actual_instance"), f"Job is None for function {function_uid} with sample {sample}. Response: {response}"
         assert response.actual_instance is not None, f"Job is None for function {function_uid} with sample {sample}. Response: {response}"

--- a/node/src/components/JobRow.tsx
+++ b/node/src/components/JobRow.tsx
@@ -6,8 +6,11 @@ import { toast } from "react-toastify";
 import { useState } from "react";
 import { PYTHON_DAKOTA_BACKEND } from "../utils/api_objects";
 import { openStudyUid } from "../utils/function_utils";
+import { useMMUXContext } from "../context/MMUXContext";
+import { ProjectFunctionJob } from "../osparc-api-ts-client";
 
 const JobRow = (props: JobRowProps) => {
+  const { selectedFunction } = useMMUXContext();
   const { jobUid, jobList, setSelected } = props;
   const job = jobList.find(j => j.job.uid === jobUid);
   const [creatingJobCopy, setCreatingJobCopy] = useState(false)
@@ -63,13 +66,18 @@ const JobRow = (props: JobRowProps) => {
       title: string;
       description: string;
     }
-    const createJobStudyCopy = async (projectJobId: string) => {
+    const createJobStudyCopy = async (job: ProjectFunctionJob) => {
       try {
+        const projectJobId = job.projectJobId;
+        const inputs = job.inputs
+        console.log("inputs: ", inputs)
         const study: StudyType = await fetch(
           PYTHON_DAKOTA_BACKEND + "/flask/clone_job", {
           method: "POST",
           body: JSON.stringify({
+            functionName: selectedFunction?.title,
             projectJobId: projectJobId,
+            projectInputs: inputs,
           }),
         }).then(function (response) {
           return response.json()
@@ -89,7 +97,7 @@ const JobRow = (props: JobRowProps) => {
     return (
       <TableRow
         key={job.job.uid}
-        sx={(theme)=>({
+        sx={(theme) => ({
           backgroundColor: jobStatus !== 'SUCCESS' ? theme.palette.grey[200] : undefined,
           '& .MuiTableCell-root': {
             color: jobStatus !== 'SUCCESS' ? theme.palette.grey[500] : undefined
@@ -130,7 +138,7 @@ const JobRow = (props: JobRowProps) => {
               size="small"
               onClick={async () => {
                 setCreatingJobCopy(true)
-                const copy_uid = await createJobStudyCopy(job.job.projectJobId);
+                const copy_uid = await createJobStudyCopy(job.job);
                 setCreatingJobCopy(false)
                 if (copy_uid) openStudyUid(copy_uid)
                 else toast.warning("Could not open Job copy in new window!")

--- a/node/src/components/RunSingleJob.tsx
+++ b/node/src/components/RunSingleJob.tsx
@@ -50,7 +50,8 @@ const TestJob = () => {
     const job = await runTestJob(context, jobInputs);
     console.log("TestJob created: ", job);
     // open in a new window - like in "View" of the JobList
-    if (job && job.functionClass && job.functionClass === "PROJECT") openStudyUid(job.projectJobId)
+    if (!job) toast.warning("Test Job running failed! Please contact support");
+    else if (job.functionClass && job.functionClass === "PROJECT") openStudyUid(job.projectJobId)
     else toast.warning("Only ProjectFunctionJob can be opened in a new window!");
   };
 


### PR DESCRIPTION
Introduces the PROJECT_ID and NODE_ID retrieval which are necessary for some of the interactions with the OSPARC API (so that billing information is consistently tracked). 

So far, have been fixed:
- Map (LHS and Grid sampling)
- Test sampling
- Cloning

I do not believe there is anything else that needs changes but we might find it along the way.
PS cloning does NOT need those credentials (and it would fail if included). I guess because nothing is actually running, it just copies data.