### PR TITLE
feat: Added state persistency via file and created loading mechanism

### DIFF
--- a/node/src/context/MMUXContext.tsx
+++ b/node/src/context/MMUXContext.tsx
@@ -1,9 +1,29 @@
-import React, { createContext, useContext, useMemo, useState } from "react";
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
 import {
   Function,
   FunctionJob,
   RegisteredFunctionJobCollection,
 } from "../osparc-api-ts-client";
+import { PersistenceContext, PersistenceContextProvider, usePersistenceContext } from "./PersistenceContext";
+
+export interface MMUXDataType {
+  selectedFunction: Function | undefined;
+  distribution: { [key: string]: InputVarSelection };
+  inputVars: string[];
+  outputVars: string[] | undefined;
+  currentView: number;
+  launchingSampling: boolean;
+  runningSampling: boolean;
+  lhsSamplingConfig: LHSamplingConfig;
+  gridSamplingConfig: GRIDSamplingConfig;
+  singleJobConfig: SingleJobConfig[];
+  numSamples: { [key: string]: number };
+  runningJobCollection: RegisteredFunctionJobCollection | undefined;
+  fetchedJobCollections: SelectedJobCollection[];
+  selectedJobUids: string[];
+  selectedQoI: string | undefined;
+  isSuMoGenerated: boolean;
+}
 
 export interface MMUXContextType {
   selectedFunction: Function | undefined;
@@ -63,33 +83,35 @@ const defaultGRIDamplingConfig: GRIDSamplingConfig = [];
 const defaultSingleJobConfig: SingleJobConfig[] = [];
 
 export const MMUXContextProvider = ({ children }: Props) => {
-  const [currentView, setCurrentView] = useState(0);
-  const [funct, setFunct] = useState<Function | undefined>(undefined);
-  const [launchingSampling, setLaunchingSampling] = useState<boolean>(false);
-  const [runningSampling, setRunningSampling] = useState<boolean>(false);
+  const {persistence, saveState} = usePersistenceContext();
+  const [currentView, setCurrentView] = useState(persistence?.currentView || 0);
+  const [funct, setFunct] = useState<Function | undefined>(persistence?.selectedFunction || undefined);
+  const [launchingSampling, setLaunchingSampling] = useState<boolean>(persistence?.launchingSampling || false);
+  const [runningSampling, setRunningSampling] = useState<boolean>(persistence?.runningSampling || false);
   const [lhsSamplingConfig, setLhsSamplingConfig] = useState<LHSamplingConfig>(
-    defaultLHSamplingConfig
+    persistence?.lhsSamplingConfig || defaultLHSamplingConfig
   );
   const [gridSamplingConfig, setGridSamplingConfig] =
-    useState<GRIDSamplingConfig>(defaultGRIDamplingConfig);
+    useState<GRIDSamplingConfig>(persistence?.gridSamplingConfig || defaultGRIDamplingConfig);
   const [singleJobConfig, setSingleJobConfig] = useState<SingleJobConfig[]>(
-    defaultSingleJobConfig
+    persistence?.singleJobConfig || defaultSingleJobConfig
   );
-  const [selectedJobUids, setSelectedJobUids] = useState<Array<string>>([]);
+  const [selectedJobUids, setSelectedJobUids] = useState<Array<string>>(persistence?.selectedJobUids || []);
   const [fetchedJobCollections, setFetchedJobCollections] = useState<
     SelectedJobCollection[]
-  >([]);
-  const [inputVars, setInputVars] = useState<string[]>([]);
+  >(persistence?.fetchedJobCollections || []);
+  const [inputVars, setInputVars] = useState<string[]>(persistence?.inputVars || []);
   const [distribution, setDistribution] = useState<{
     [key: string]: InputVarSelection;
-  }>({});
-  const [numSamples, setNumSamples] = useState<{ [key: string]: number }>({});
-  const [outputVars, setOutputVars] = useState<string[] | undefined>(undefined);
-  const [selectedQoI, setSelectedQoI] = useState<string | undefined>(undefined);
+  }>(persistence?.distribution || {});
+  const [numSamples, setNumSamples] = useState<{ [key: string]: number }>(persistence?.numSamples || {});
+  const [outputVars, setOutputVars] = useState<string[] | undefined>(persistence?.outputVars || undefined);
+  const [selectedQoI, setSelectedQoI] = useState<string | undefined>(persistence?.selectedQoI || undefined);
   const [runningJobCollection, setRunningJobCollection] = useState<
     RegisteredFunctionJobCollection | undefined
-  >(undefined);
-  const [isSuMoGenerated, setIsSuMoGenerated] = useState<boolean>(false);
+  >(persistence?.runningJobCollection || undefined);
+  const [isSuMoGenerated, setIsSuMoGenerated] = useState<boolean>(persistence?.isSuMoGenerated || false);
+  const [loading, setLoading] = useState<boolean>(true);
 
   const handleSelectedFunction = (F: Function | undefined) => {
     setFunct(F);
@@ -101,34 +123,103 @@ export const MMUXContextProvider = ({ children }: Props) => {
     setSingleJobConfig(defaultSingleJobConfig);
   };
 
+  const filterSelectedJobList = () => {
+    const response: FunctionJob[] = fetchedJobCollections.flatMap(
+      (jobCollection) =>
+        jobCollection.subJobs
+          .filter((subJob) => subJob.selected)
+          .map((subJob) => subJob.job)
+    );
+
+    if (fetchedJobCollections.length !== 0 && response.length < 5) {
+      return []; // 5 samples are necessary to avoid Dakota crashing
+    }
+    return response;
+  };
+
+  const allJobsList = () => {
+    const response: FunctionJob[] = fetchedJobCollections.flatMap(
+      (jobCollection) =>
+        jobCollection.subJobs
+          .map((subJob) => subJob.job)
+    );
+
+    if (fetchedJobCollections.length !== 0 && response.length <= 4) {
+      return []; // 5 samples are necessary to avoid Dakota crashing
+    }
+    return response;
+  };
+
+  // persist the state of the MMUX context using the persistenceContext provider every time any of the state variables change
+  useEffect(() => {
+    if(loading) return; // Avoid saving state while loading
+    console.info("Saving MMUX context state to persistence...");
+    saveState({
+      selectedFunction: funct,
+      distribution: distribution,
+      inputVars: inputVars,
+      outputVars: outputVars,
+      currentView: currentView,
+      launchingSampling: launchingSampling,
+      lhsSamplingConfig: lhsSamplingConfig,
+      gridSamplingConfig: gridSamplingConfig,
+      singleJobConfig: singleJobConfig,
+      runningSampling: runningSampling,
+      numSamples: numSamples,
+      selectedQoI: selectedQoI,
+      runningJobCollection: runningJobCollection,
+      fetchedJobCollections: fetchedJobCollections,
+      selectedJobUids: selectedJobUids,
+      isSuMoGenerated: isSuMoGenerated,
+    });
+  }, [
+    currentView,
+    funct,
+    launchingSampling,
+    runningSampling,
+    lhsSamplingConfig,
+    gridSamplingConfig,
+    singleJobConfig,
+    selectedJobUids,
+    fetchedJobCollections,
+    inputVars,
+    distribution,
+    numSamples,
+    outputVars,
+    selectedQoI,
+    runningJobCollection,
+    isSuMoGenerated,
+  ]);
+
+  useEffect(() => {
+    if(loading && persistence !== undefined) {
+      console.info("Loading MMUX context state from persistence...", JSON.stringify(persistence), typeof persistence.currentView !== 'number');
+      if(typeof persistence.currentView !== 'number') {
+        console.info("Persistence file is empty, initializing with default values.");
+        setLoading(false);
+        return;
+      }
+      setFunct(persistence.selectedFunction);
+      setDistribution(persistence.distribution);
+      setInputVars(persistence.inputVars);
+      setOutputVars(persistence.outputVars);
+      setCurrentView(persistence.currentView);
+      setLaunchingSampling(persistence.launchingSampling);
+      setRunningSampling(persistence.runningSampling);
+      setLhsSamplingConfig(persistence.lhsSamplingConfig);
+      setGridSamplingConfig(persistence.gridSamplingConfig);
+      setSingleJobConfig(persistence.singleJobConfig);
+      setNumSamples(persistence.numSamples);
+      setSelectedQoI(persistence.selectedQoI);
+      setRunningJobCollection(persistence.runningJobCollection);
+      setFetchedJobCollections(persistence.fetchedJobCollections);
+      setSelectedJobUids(persistence.selectedJobUids);
+      setIsSuMoGenerated(persistence.isSuMoGenerated);
+      setLoading(false); // Set loading to false after loading the state
+    }
+  }, [persistence, loading]);
+
   const memoState = useMemo(() => {
-    const filterSelectedJobList = () => {
-      const response: FunctionJob[] = fetchedJobCollections.flatMap(
-        (jobCollection) =>
-          jobCollection.subJobs
-            .filter((subJob) => subJob.selected)
-            .map((subJob) => subJob.job)
-      );
-
-      if (fetchedJobCollections.length !== 0 && response.length < 5) {
-        return []; // 5 samples are necessary to avoid Dakota crashing
-      }
-      return response;
-    };
-
-    const allJobsList = () => {
-      const response: FunctionJob[] = fetchedJobCollections.flatMap(
-        (jobCollection) =>
-          jobCollection.subJobs
-            .map((subJob) => subJob.job)
-      );
-
-      if (fetchedJobCollections.length !== 0 && response.length <= 4) {
-        return []; // 5 samples are necessary to avoid Dakota crashing
-      }
-      return response;
-    };
-
     return {
       selectedFunction: funct,
       setSelectedFunction: handleSelectedFunction,

--- a/node/src/context/PersistenceContext.tsx
+++ b/node/src/context/PersistenceContext.tsx
@@ -1,0 +1,122 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { MMUXDataType } from './MMUXContext';
+import { toast } from 'react-toastify';
+
+const LOCAL_BASE_URL = "http://localhost:8888";
+const DOCKER_BASE_URL = "http://67316004-27e9-4493-9885-23305dc65db3.services.10.43.103.168.nip.io:9081";
+const BASE_URL = process.env.NODE_ENV === "development" ? LOCAL_BASE_URL : DOCKER_BASE_URL;
+const COOKIE_NAME = "osparc-sc2";
+const COOKIE_VALUE = "gAAAAABodgUAlkp8gMu1vJQ2BTAeRCPCwhDkEEJF1CK2pJcpCXQh5PNTNLF6bPIdYum4cDVUFYEwMXTdw2gRseN4p7mGvWi8NlJu6xA8EiXx0nvqDtzXzEXS9VWHYO-uLbpFHbqJLrCN1gfwH-CUcgxmncsy1KWCTDkUmQNCJm9EauHBw7WdcgbQnOuksYO2H71jHGKRGO1JUugqpHhM0Pr5IGjsP-EpvEwEj0-EcrL0hAILZNPtGrG1yFjgizA-K6Drn8EMnXjjfgEFr8V9cK12j3oWRBN9i6-_dgv3V8k97f6m9CTROUgRUtnyBADCkWjGiC7Gk0Go3JQ2THDp1dAISnRskwN9MLS8uSKvxa5hRpWANLvEx91IFxUxSZmWJopxWtWn0mv6jWK8035OzCCcY910V8w-Kb7FV7Un6jshMXqGVdVJIUHhZN7Oa4jvMeRTBZ9SgHBfu6GEIfjpB8bN8Lt-x7Gv6OJnA0vjUcQzEuUYABWHQZmwJ5dgNwPr3Herp6RqOrOxTND0JjU65eMPmZIW0Edn7Q==";
+
+
+interface PersistenceContextType {
+  persistence: MMUXDataType | undefined;
+  saveState: (state: MMUXDataType) => Promise<void>;
+}
+
+export const PersistenceContext = createContext<PersistenceContextType>(undefined!);
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const PersistenceContextProvider = ({ children }: Props) => {
+  const [persistence, setPersistence] = useState<MMUXDataType | undefined>(undefined);
+
+  const getHeaders = (contentType = true): HeadersInit => {
+    return {
+      ...(contentType ? { "Content-Type": "application/json" } : {}),
+      "Cookie": `${COOKIE_NAME}=${COOKIE_VALUE}`
+    };
+  }
+
+  const setFile = async (filename: string, content: string) => {
+    const response = await fetch(`${BASE_URL}/flask/text-file`, {
+      method: "POST",
+      headers: getHeaders(),
+      body: JSON.stringify({ filename, content }),
+      credentials: "include"
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to set file: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json() as { filename: string, status: string };
+    if(data.status !== 'success' || data.filename !== filename) {
+      throw new Error(`Failed to set file: ${data.status}`);
+    }
+
+    console.info(`File ${data.filename} saved successfully.`);
+  }
+
+  const getFile = async (filename: string): Promise<MMUXDataType | undefined> => {
+    const response = await fetch(`${BASE_URL}/flask/text-file/${encodeURIComponent(filename)}`, {
+      method: "GET",
+      headers: getHeaders(false),
+      credentials: "include"
+    });
+
+    if (!response.ok) {
+      if( response.status === 404) {
+        console.warn(`⚠️ Could not retrieve file (${response.status}): ${response.statusText}`);
+        return {} as MMUXDataType; // Return empty object if file not found
+      } else {
+        throw new Error(`Failed to fetch file: ${response.status} ${response.statusText}`);
+      }
+    }
+
+    const envelope = await response.json() as {content: string, filename: string};
+    const data = JSON.parse(envelope.content) as MMUXDataType;
+    console.info(`File ${filename} fetched successfully.`, data);
+    return data;
+  }
+
+  const saveState = async (state: MMUXDataType) => {
+    const content = JSON.stringify(state, null, 2);
+    console.log("Saving state to persistence file:", content);
+    try {
+      await setFile('persistence.json', content);
+      setPersistence(state);
+    } catch (error) {
+      console.error("Error saving state:", error);
+    }
+  }
+
+  useEffect(() => {
+    const fetchFile = async () => {
+      try {
+        const persistenceFile = await getFile('persistence.json');
+        if (persistenceFile === undefined) {
+          console.info("No persistence file found, initializing with empty state.");
+        } else {
+          setPersistence(persistenceFile);
+        }
+      } catch (error) {
+        console.error("Error when fetching persistence file:", error);
+        toast.error("Failed to fetch user state, starting from scratch.");
+      }
+    };
+
+    fetchFile();
+  }, []);
+
+  const memo = React.useMemo(() => ({
+    persistence,
+    saveState
+  }), [persistence]);
+
+  return (
+    <PersistenceContext.Provider value={memo}>
+      {children}
+    </PersistenceContext.Provider>
+  );
+};
+
+export const usePersistenceContext = () => {
+  const context = useContext(PersistenceContext);
+  if (context === undefined) {
+    throw new Error('usePersistenceContext must be used within a PersistenceContextProvider');
+  }
+  return context;
+}

--- a/node/src/index.tsx
+++ b/node/src/index.tsx
@@ -2,9 +2,12 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 import { MMUXContextProvider } from "./context/MMUXContext.tsx";
+import { PersistenceContextProvider } from "./context/PersistenceContext.tsx";
 
 createRoot(document.getElementById("root")!).render(
-  <MMUXContextProvider>
-    <App />
-  </MMUXContextProvider>
+  <PersistenceContextProvider>
+    <MMUXContextProvider>
+      <App />
+    </MMUXContextProvider>
+  </PersistenceContextProvider>
 );


### PR DESCRIPTION
With this PR we add the PersistencyContext, which ensures the retrieval and storage of the required states. 

To use it, it should be imported on every context that wants to persist its information, right now all states are concentrated in MMuXContext but that will change, when it happens, every state should have it's own function to store on the persistence side the elements that are required on the memory, and when to save them.