### PR TITLE
fix: added template and uuid fields to the openFunction message

### DIFF
--- a/node/src/components/setup/FunctionList.tsx
+++ b/node/src/components/setup/FunctionList.tsx
@@ -101,7 +101,6 @@ export function FunctionList() {
             type: "openFunction",
             message: {
               functionId: (fun as ProjectFunction).projectId,
-              templateId: (fun as ProjectFunction).projectId,
               uuid: (fun as ProjectFunction).uid,
             },
           },


### PR DESCRIPTION
This Osparc function now has this structure:

``` TS
{
  type: "openFunction",
  message: {
    functionId: (fun as ProjectFunction).projectId,
    uuid: (fun as ProjectFunction).uid,
  },
},
```

The new field holds the Function ID and the old `functionId` field keeps the already passed template ID