### PR TITLE
feat: Started to split into separate components the current monolithic context

### DIFF
--- a/node/src/App.tsx
+++ b/node/src/App.tsx
@@ -5,14 +5,15 @@ import { toast, ToastContainer } from "react-toastify";
 import { setupTheme } from "./theme";
 import Navigation from "./components/navigation/Navigation";
 import { Footer } from "./components/navigation/Footer";
-import { useMMUXContext } from "./context/MMUXContext";
+import { useNavigationContext } from "./context/NavigationContext";
 import { getHealth } from "./utils/function_utils";
 import { SplashScreen } from "./views/SplashScreen";
 import { ServiceContextProvider } from "./context/ServiceContext";
 import PreviewWarning from "./components/navigation/PreviewWarning";
 import { ReturnCurrentView } from "./views/ReturnCurrentView";
+import { MMUXContextProvider } from "./context/MMUXContext";
 
-const FakeRoot = styled("div")(
+const AppRoot = styled("div")(
   ({ theme }) => `
   min-height: 100vh;
   height: 100%;
@@ -23,11 +24,7 @@ const FakeRoot = styled("div")(
 const App = () => {
   const [healthStatus, setHealthStatus] = useState<boolean>(false);
 
-  const steps: Step[] = [
-    { id: 0, label: "Setup" },
-    { id: 1, label: "Results" },
-  ];
-  const { currentView } = useMMUXContext();
+  const { currentView, steps } = useNavigationContext();
   const { mode, systemMode, setMode } = useColorScheme();
   const finalMode = mode
     ? mode === "system"
@@ -112,18 +109,20 @@ const App = () => {
 
   return (
     <ThemeProvider theme={theme}>
-      <FakeRoot>
+      <AppRoot>
         {!healthStatus ? (
           <SplashScreen />
         ) : (
-          <ServiceContextProvider>
-            <PreviewWarning />
-            <Container sx={{ paddingBottom: 4 }}>
-              <Navigation steps={steps} activeStep={currentView} />
-              <ReturnCurrentView currentView={currentView} />
-              <Footer steps={steps} />
-            </Container>
-          </ServiceContextProvider>
+          <MMUXContextProvider>
+            <ServiceContextProvider>
+              <PreviewWarning />
+              <Container sx={{ paddingBottom: 4 }}>
+                <Navigation steps={steps} activeStep={currentView} />
+                <ReturnCurrentView currentView={currentView} />
+                <Footer steps={steps} />
+              </Container>
+            </ServiceContextProvider>
+          </MMUXContextProvider>
         )}
         <ToastContainer
           theme={themeMode}
@@ -137,7 +136,7 @@ const App = () => {
           draggable={false}
           pauseOnHover
         />
-      </FakeRoot>
+      </AppRoot>
     </ThemeProvider>
   );
 };

--- a/node/src/components/navigation/Footer.tsx
+++ b/node/src/components/navigation/Footer.tsx
@@ -3,6 +3,7 @@ import { Button, Modal, Paper } from "@mui/material";
 import { useMMUXContext } from "../../context/MMUXContext";
 import JobsDashboard from "../../views/ParallelRunner";
 import { stepValidator } from "../../utils/stepValidator";
+import { useNavigationContext } from "../../context/NavigationContext";
 
 type FooterProps = {
   steps: Step[];
@@ -10,8 +11,9 @@ type FooterProps = {
 
 export const Footer = (props: FooterProps) => {
   const { steps } = props;
+  const { currentView, setCurrentView } = useNavigationContext();
   const context = useMMUXContext();
-  const { currentView, setCurrentView, runningSampling } = context;
+  const { runningSampling } = context;
   const [modal, setModal] = React.useState(false);
   const isJobsRunning = runningSampling;
 

--- a/node/src/context/MMUXContext.tsx
+++ b/node/src/context/MMUXContext.tsx
@@ -11,7 +11,6 @@ export interface MMUXDataType {
   distribution: { [key: string]: InputVarSelection };
   inputVars: string[];
   outputVars: string[] | undefined;
-  currentView: number;
   launchingSampling: boolean;
   runningSampling: boolean;
   lhsSamplingConfig: LHSamplingConfig;
@@ -34,8 +33,6 @@ export interface MMUXContextType {
   setInputVars: (vars: string[]) => void;
   outputVars: string[] | undefined;
   setOutputVars: (vars: string[]) => void;
-  currentView: number;
-  setCurrentView: (i: number) => void;
   launchingSampling: boolean;
   setLaunchingSampling: (b: boolean) => void;
   runningSampling: boolean;
@@ -84,7 +81,6 @@ const defaultSingleJobConfig: SingleJobConfig[] = [];
 
 export const MMUXContextProvider = ({ children }: Props) => {
   const {persistence, saveState} = usePersistenceContext();
-  const [currentView, setCurrentView] = useState(persistence?.currentView || 0);
   const [funct, setFunct] = useState<Function | undefined>(persistence?.selectedFunction || undefined);
   const [launchingSampling, setLaunchingSampling] = useState<boolean>(persistence?.launchingSampling || false);
   const [runningSampling, setRunningSampling] = useState<boolean>(persistence?.runningSampling || false);
@@ -159,7 +155,6 @@ export const MMUXContextProvider = ({ children }: Props) => {
       distribution: distribution,
       inputVars: inputVars,
       outputVars: outputVars,
-      currentView: currentView,
       launchingSampling: launchingSampling,
       lhsSamplingConfig: lhsSamplingConfig,
       gridSamplingConfig: gridSamplingConfig,
@@ -173,7 +168,6 @@ export const MMUXContextProvider = ({ children }: Props) => {
       isSuMoGenerated: isSuMoGenerated,
     });
   }, [
-    currentView,
     funct,
     launchingSampling,
     runningSampling,
@@ -194,8 +188,8 @@ export const MMUXContextProvider = ({ children }: Props) => {
 
   useEffect(() => {
     if(loading && persistence !== undefined) {
-      console.info("Loading MMUX context state from persistence...", JSON.stringify(persistence), typeof persistence.currentView !== 'number');
-      if(typeof persistence.currentView !== 'number') {
+      console.info("Loading MMUX context state from persistence...", JSON.stringify(persistence), typeof persistence.launchingSampling !== 'boolean');
+      if(typeof persistence.launchingSampling !== 'boolean') {
         console.info("Persistence file is empty, initializing with default values.");
         setLoading(false);
         return;
@@ -204,7 +198,6 @@ export const MMUXContextProvider = ({ children }: Props) => {
       setDistribution(persistence.distribution);
       setInputVars(persistence.inputVars);
       setOutputVars(persistence.outputVars);
-      setCurrentView(persistence.currentView);
       setLaunchingSampling(persistence.launchingSampling);
       setRunningSampling(persistence.runningSampling);
       setLhsSamplingConfig(persistence.lhsSamplingConfig);
@@ -230,8 +223,6 @@ export const MMUXContextProvider = ({ children }: Props) => {
       setInputVars: setInputVars,
       outputVars: outputVars,
       setOutputVars: setOutputVars,
-      currentView: currentView,
-      setCurrentView: setCurrentView,
       launchingSampling: launchingSampling,
       setLaunchingSampling: setLaunchingSampling,
       lhsSamplingConfig: lhsSamplingConfig,
@@ -262,7 +253,6 @@ export const MMUXContextProvider = ({ children }: Props) => {
     distribution,
     inputVars,
     outputVars,
-    currentView,
     launchingSampling,
     lhsSamplingConfig,
     gridSamplingConfig,

--- a/node/src/context/NavigationContext.tsx
+++ b/node/src/context/NavigationContext.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+interface NavigationContextType {
+  currentView: number;
+  setCurrentView: (view: number) => void;
+  steps: Step[];
+}
+
+export const NavigationContext = createContext<NavigationContextType>(undefined!);
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const NavigationContextProvider = ({ children }: Props) => {
+  const [currentView, setCurrentView] = useState(0);
+  const steps: Step[] = [
+    { id: 0, label: "Setup" },
+    { id: 1, label: "Results" },
+  ];
+
+  useEffect(() => {
+    const fetchStatus = async () => {
+      try {
+        setCurrentView(0);
+      } catch (error) {
+        console.error("Backend is not responding with permissions:", error);
+      }
+    };
+
+    fetchStatus();
+  }, []);
+
+  const memo = React.useMemo(() => ({
+    currentView,
+    setCurrentView,
+    steps,
+  }), [currentView, setCurrentView, steps]);
+
+  return (
+    <NavigationContext.Provider value={memo}>
+      {children}
+    </NavigationContext.Provider>
+  );
+};
+
+export const useNavigationContext = () => {
+  const context = useContext(NavigationContext);
+  if (context === undefined) {
+    throw new Error('useNavigationContext must be used within a NavigationContextProvider');
+  }
+  return context;
+}

--- a/node/src/index.tsx
+++ b/node/src/index.tsx
@@ -1,13 +1,13 @@
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
-import { MMUXContextProvider } from "./context/MMUXContext.tsx";
 import { PersistenceContextProvider } from "./context/PersistenceContext.tsx";
+import { NavigationContextProvider } from "./context/NavigationContext.tsx";
 
 createRoot(document.getElementById("root")!).render(
   <PersistenceContextProvider>
-    <MMUXContextProvider>
+    <NavigationContextProvider>
       <App />
-    </MMUXContextProvider>
+    </NavigationContextProvider>
   </PersistenceContextProvider>
 );


### PR DESCRIPTION
## Issue
MMuXContext takes care of too many things right now, it's easy to persist it but difficult to reuse and maintain

## Solution
The monolithic state should be refactored into:
- [ ] PersistenceContext 
- [ ] NavigationContext
- [ ] FunctionContext
- [ ] JobContext
- [ ] SamplingContext
- [ ] Specific context for each tool (SUMO, UQ, MOGA)