### PR TITLE
Fix missing /text-files directory in images

### DIFF
--- a/.osparc/proxy-moga-read/runtime.yml
+++ b/.osparc/proxy-moga-read/runtime.yml
@@ -14,7 +14,8 @@ settings:
 paths-mapping:
   inputs_path: /tmp/inputs
   outputs_path: /tmp/outputs
-  state_paths: []
+  state_paths:
+    - /text-files
 
 compose-spec:
   version: "3.8"

--- a/.osparc/proxy-moga-write/runtime.yml
+++ b/.osparc/proxy-moga-write/runtime.yml
@@ -14,7 +14,9 @@ settings:
 paths-mapping:
   inputs_path: /tmp/inputs
   outputs_path: /tmp/outputs
-  state_paths: []
+  state_paths:
+    - /text-files
+  
 
 compose-spec:
   version: "3.8"

--- a/.osparc/proxy-moga-write/runtime.yml
+++ b/.osparc/proxy-moga-write/runtime.yml
@@ -16,8 +16,6 @@ paths-mapping:
   outputs_path: /tmp/outputs
   state_paths:
     - /text-files
-  
-
 compose-spec:
   version: "3.8"
   services:


### PR DESCRIPTION
The MOGA runtime.yml files were missing the entry that creates the /text-files directory. Which was causing the front-end to fail.