### PR TITLE
Increase number of gunicorn workers to 4

### DIFF
--- a/flaskapi/entrypoint.sh
+++ b/flaskapi/entrypoint.sh
@@ -17,7 +17,7 @@ export LOG_LEVEL=${LOG_LEVEL:-INFO}
 
 # NOTE: only required to test in local oSPARC deployment
 # uncomment and adjust with correct IP and PORT where the api servver is exposed
-# export OSPARC_API_BASE_URL=api.10.43.103.120.nip.io:8006
+# export OSPARC_API_BASE_URL=api.10.211.55.3.nip.io:8006
 
 if [ "$DEVELOPMENT_MODE" = "true" ]; then
     # Development mode - use Flask's built-in server
@@ -35,7 +35,7 @@ else
     # Production mode - use gunicorn
     echo "$INFO" "Starting gunicorn production server on $HOST:$PORT"
     exec gunicorn --bind "$HOST:$PORT" \
-        --workers=1 \
+        --workers=4 \
         --worker-class=gevent \
         --timeout=120 \
         --access-logfile=- \


### PR DESCRIPTION
This is a temporary fix to not starve the flask api when a longer moga is running.

Longer term solutions could be:
- Run moga itself using the functions api
- Use celery workers in the flask backend

Closes #352 #351 