### PR TITLE
docs(spec): backprop #467/#468/#469 review findings + 0811bcb conventions

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -73,6 +73,7 @@ T3|.|README lacks run matrix doc (modes×perms = 12 `run-*` targets); document|�
 T4|.|verify `tests/e2e/` covers proxy routing `/flask/*` split & service-mode view switch|V1,V2
 T5|.|`concepts/` holds only UX `.pptx` (2025-01-13, 2025-02-17), not code — confirm intentional, link from README?|—
 T6|.|PORT-TRACKER: clean re-port of feature/local-functions + test/playwright-automation + jgo/preserve-case work (prior merge garbled React state). 6 topics, 1 worktree/branch each off this SPEC: (a) be-preserve-case [full-stack, own worktree] → flaskapi T8 + node T10; (b) be-local-functions → flaskapi T7 + node T7; (c) fullstack-csv → flaskapi T6 + node T6; (d) fe-state-mgmt → node T5; (e) fullstack-logscale → flaskapi T9 + node T8; (f) testing-e2e → node T9 + T4. ⊥ port branch artifacts `INVARIANTS.md`/`LIVE_DEBUGGING.md`/`.serena/memories/*`/`tmp_job_collection_import.csv` (intent already folded into §V)|node/SPEC.md T5-T9, flaskapi/SPEC.md T6-T9
+T7|.|REVIEW-BACKPROP: re-port PRs #467(be)/#468(fe-state)/#469(preserve-case) rebased onto develop (single feature commit each, squashed SPEC base #466 dropped). Copilot review findings recorded as bugs+fix-tasks: flaskapi §B1-B5/§T10-T14, node §B6-B9/§T11-T13. alexpargon structural fixes (commit `0811bcb`) folded into node §C conventions + carry-over task node §T14. ⊥ merge before §T fixes addressed|flaskapi/SPEC.md T10-T14, node/SPEC.md T11-T14
 
 ## §B
 id|date|cause|fix

--- a/flaskapi/SPEC.md
+++ b/flaskapi/SPEC.md
@@ -91,6 +91,11 @@ V13: response serializer ⊥ snake↔camel-convert keys ∈ value dicts `{inputs
 V14: orig variable-name case preserved through `DataPreprocessor` x1..xn round-trip + serialization (⊥ lowercase); preserve-case driven by function metadata (`has_preserve_case_metadata`) — distilled, to port (§T8)
 V15: `DEPLOYMENT_MODE=LOCAL` ⇒ functions/collections/jobs MAY resolve from `local_job_store` w/o live oSPARC; uid-prefix routes local-vs-oSPARC ∀ osparc/sampling/dakota lookup — distilled, to port (§T7)
 V16: log-scale per-variable flag (from request payload) reaches Dakota preprocessing → sample/train in log space, inverse on response (⊥ train linear when UI=log) — distilled, to port (§T9, node/SPEC.md V12)
+--- review-backprop invariants (Copilot review on #467; bugs §B1-B5, fixes §T10-T14) ---
+V17: `local_job_store` dir anchored to explicit base (env `LOCAL_STORE_DIR` or `Path(__file__).resolve().parents[N]`), ⊥ `Path.cwd()`-derived; mkdir deferred to first write + `parents=True` (B1)
+V18: response ⊥ emit same datum under both snake+camel key when global serializer camel-converts (⊥ pre-add `jobIds` beside `job_ids`) → ⊥ key-collision overwrite (B2)
+V19: CSV cell parse ! raise ValueError w/ row+col ctx on unparseable non-blank cell; truly-blank → NaN sentinel, ⊥ silent `0.0` (⊥ feed accidental zeros to Dakota) (B4)
+V20: `local_job_store._load_store` catches only `(OSError, json.JSONDecodeError)`; on corrupt JSON ! backup offending file, ⊥ silent reset-then-overwrite (⊥ unrecoverable loss) (B5)
 
 ## §T
 id|status|task|cites
@@ -103,6 +108,16 @@ T6|.|PORT [topic=fullstack-csv] job-collection CSV import/export: GET `/osparc/d
 T7|.|PORT [topic=be-local-functions] `utils/local_job_store.py` + local resolution paths in osparc/sampling/dakota so DEPLOYMENT_MODE=LOCAL serves uploaded/synthetic functions offline; uid-prefix routing; tests|I, V15
 T8|.|PORT [topic=be-preserve-case] `utils/case_preserving.py` + `json_serializer` `preserve_nested_keys` + `DataPreprocessor` orig-case round-trip; tests `test_utils_helpers`/`test_data_preprocessor`|I, V13, V14
 T9|.|PORT [topic=fullstack-logscale] accept per-variable log-scale flag in dakota request models → preprocess sample/train in log space, inverse on response; tests|V16, ../node/SPEC.md V12
+T10|.|fix B1 (#467): anchor `LOCAL_STORE_DIR` to env/`__file__`, defer `mkdir(parents=True)` to first write; test cwd-independence|V17,B1
+T11|.|fix B2 (#467): drop manual `jobIds` (or the snake key), let global serializer convert `job_ids` once; test ⊥ double-key collision|V18,B2
+T12|.|fix B3 (#467): gate `list_local_*` merges + per-id local branches (`osparc.py` ~94,135,160,185,224,348) on `DEPLOYMENT_MODE=LOCAL`; test OSPARC mode ⊥ surface `runs_local` state|V15,B3
+T13|.|fix B4 (#467): `_parse_number` raise ValueError(row,col) on unparseable non-blank, blank→NaN; test rejects `"abc"`/swapped cols|V19,B4
+T14|.|fix B5 (#467): narrow `_load_store` except to `(OSError, json.JSONDecodeError)`, backup before reset; test corrupt-json ⊥ wipe store|V20,B5
 
 ## §B
 id|date|cause|fix
+B1|2026-06-16|#467 `local_job_store` `LOCAL_STORE_DIR=Path.cwd().parent.parent.parent` at import → cwd-dependent unpredictable path (pytest cwd ≠ container cwd), `mkdir` no `parents`|V17
+B2|2026-06-16|#467 `osparc.py` normalized collection emits both `jobIds`+`job_ids`; global camel serializer rewrites `job_ids`→`jobIds` → key collision, one silently overwrites (iteration-order dependent)|V18
+B3|2026-06-16|#467 `osparc.py` local fn/collection merges + per-id branches run unconditionally ∀ `DEPLOYMENT_MODE` → OSPARC deploy leaks leftover `runs_local` state, violates V15|V15
+B4|2026-06-16|#467 `sampling._parse_number` swallows unparseable cell → `0.0` → silent scientific-data corruption (job looks completed w/ zeros fed to Dakota)|V19
+B5|2026-06-16|#467 `local_job_store._load_store` bare `except Exception`→empty store; next `_save_store` overwrites corrupt file → unrecoverable loss of saved functions/collections/jobs|V20

--- a/node/SPEC.md
+++ b/node/SPEC.md
@@ -19,8 +19,8 @@ Vite + React 19 + TS frontend: guided 2-step meta-modeling UX (Setup → Results
 - style: functional components + hooks only; ⊥ `any`; props typed via TS (⊥ PropTypes); destructure props in signature
 - naming: Components PascalCase | funcs/vars camelCase | util/hook files kebab|camel `.ts` | constants CONSTANT_CASE
 - errors: console.warn/error dev feedback + react-toastify user-facing
---- structural conventions (alexpargon review on #456 + fix commit 0811bcb) ---
-- pure utility modules (⊥ JSX/React) live `utils/` ∀ consumer count (⊥ co-locate in `components/`); e.g. `sumoResponse.ts` belongs `utils/` not `components/plots/`
+--- structural conventions (alexpargon review on #456 + fix commit `0811bcb`) ---
+- pure utility modules (⊥ JSX/React) live `utils/` ∀ consumer count (⊥ co-locate in `components/`); e.g. (see `0811bcb`) `sumoResponse.ts` belongs `utils/` not `components/plots/`
 - shared helpers single-sourced + exported (⊥ duplicate identical defs across files); e.g. one `snakeToCamelCase` exported from `utils/functionUtils.ts`
 - test fixtures/data → `__fixtures__/` (⊥ temp data files committed in `src/` tree or repo root, e.g. `tmp_job_collection_import.csv`)
 - component internal order: theme → context hooks → derived values → state → ref → handlers → effects → layout/style obj literals → JSX return

--- a/node/SPEC.md
+++ b/node/SPEC.md
@@ -19,6 +19,11 @@ Vite + React 19 + TS frontend: guided 2-step meta-modeling UX (Setup → Results
 - style: functional components + hooks only; ⊥ `any`; props typed via TS (⊥ PropTypes); destructure props in signature
 - naming: Components PascalCase | funcs/vars camelCase | util/hook files kebab|camel `.ts` | constants CONSTANT_CASE
 - errors: console.warn/error dev feedback + react-toastify user-facing
+--- structural conventions (alexpargon review on #456 + fix commit 0811bcb) ---
+- pure utility modules (⊥ JSX/React) live `utils/` ∀ consumer count (⊥ co-locate in `components/`); e.g. `sumoResponse.ts` belongs `utils/` not `components/plots/`
+- shared helpers single-sourced + exported (⊥ duplicate identical defs across files); e.g. one `snakeToCamelCase` exported from `utils/functionUtils.ts`
+- test fixtures/data → `__fixtures__/` (⊥ temp data files committed in `src/` tree or repo root, e.g. `tmp_job_collection_import.csv`)
+- component internal order: theme → context hooks → derived values → state → ref → handlers → effects → layout/style obj literals → JSX return
 
 ## §I
 parent: [`../SPEC.md`](../SPEC.md) ; backend contract: [`../flaskapi/SPEC.md`](../flaskapi/SPEC.md) §I
@@ -63,6 +68,10 @@ V13: CSV upload → 1 authoritative parsed result drives 4 effects atomically {a
 V14: FE↔BE payload field contracts changed together (⊥ opportunistic rename one side) (INV-004, ../flaskapi V13/V14)
 V15: context-derived setters guard w/ equality check before set; ⊥ object-recreation-only retrigger → duplicate Dakota/persistence fan-out (INV-005, §T5)
 V16: Dakota plot fetches (1D/2D/3D) deduped by stable logical request key {axes,sliderValues,QoI,fn,jobList,logScale}; same key → ⊥ new fetch (INV-006, §T5)
+--- review-backprop invariants (Copilot review on #468/#469; bugs §B6-B9, fixes §T11-T13) ---
+V17: persist success-marker (`lastSavedContent`) set ONLY after confirmed OK `setFile` response; failed/non-OK save ⊥ mark content saved (else V15 equality-guard suppresses retry of the failed write) (B6, refines V15)
+V18: Dakota plot dedup key (`lastFetchedKey`) cached ONLY on fetch success (or cleared on error); transient/rejected fetch ⊥ block retry of identical inputs (B7, refines V16)
+V19: FE preserve-subtree-key set ≡ backend `_PRESERVE_SUBTREE_KEYS` (single source / test asserts equality); membership tested against canonical snake form only, ⊥ dead camelCase entries (B8,B9, pairs ../flaskapi V13/V14)
 
 ## §T
 id|status|task|cites
@@ -76,6 +85,14 @@ T7|.|PORT [topic=be-local-functions] FE support for local (uid-prefixed) functio
 T8|.|PORT [topic=fullstack-logscale] `utils/distributionDiagnostics.ts` + per-variable log-scale UI (InputVariableDist/OutputVariableDist) + log-scale plot rendering (Curves1D/Surface2D/IsoSurface3D) end-to-end per V12|V12, ../flaskapi/SPEC.md V16,T9
 T9|.|PORT [topic=testing-e2e] vitest coverage for ported utils/contexts + Playwright local SUMO e2e; port/add `vitest.browser.config.ts` before advertising `npm run test:browser` as supported. pairs root §T4|../SPEC.md T4
 T10|.|PORT [topic=be-preserve-case] homologous FE: `utils/functionUtils.ts` `camelToSnakeCase`/`toBackendVarNames` + `normalizePayloadToCamelCase` preserve nested value-key dicts {inputs,outputs,properties} (mirror of backend nested-key serialization); vitest `functionUtils.test.ts`. own worktree w/ flaskapi T8|V14, ../flaskapi/SPEC.md T8,V13
+T11|.|fix B6 (#468): update `lastSavedContent` only after confirmed OK `setFile`; surface save success/failure so failed write retries; test failed-save ⊥ marked saved|V17,B6
+T12|.|fix B7 (#468): move `lastFetchedKey` update to success path (or clear on error) in Curves1DPlot/Surface2DPlot/IsoSurface3DPlot; test transient-failure retry w/ same inputs|V18,B7
+T13|.|fix B8+B9 (#469): sync FE `preserveSubtreeKeys` with backend `_PRESERVE_SUBTREE_KEYS` (single source / equality test); drop unreachable camelCase entries (`defaultInputs`/`gridData`)|V19,B8,B9,../flaskapi/SPEC.md V13
+T14|.|0811bcb [wave-2 carry-over] when opening node csv(T6)/local-fn(T7)/logscale(T8) PRs, apply alexpargon fixes from commit `0811bcb`: (a) move `sumoResponse.ts` `components/plots/`→`utils/` + fix 5 plot imports; (b) export `snakeToCamelCase` from `functionUtils`, dedup in `sumoResponse`; (c) drop dead `@mui/x-data-grid` mocks in `FunctionList.test.tsx`+`FunctionList.upload.test.tsx`; (d) rename `jobcollection_roundtrip.integration.test.ts`→camelCase; (e) `tmp_job_collection_import.csv`→`__fixtures__/jobCollectionImport.csv`; (f) `stepValidator` param `ServiceMode`→`serviceMode` (closes #471)|§C,T6,T7,T8
 
 ## §B
 id|date|cause|fix
+B6|2026-06-16|#468 `PersistenceContext` sets `lastSavedContent` even when `setFile` returns non-OK (⊥ throw) → V15 equality-guard then skips retry of the failed save|V17
+B7|2026-06-16|#468 plots cache `lastFetchedKey` before fetch resolves → failed/rejected fetch blocks retry of same inputs (Curves1D/Surface2D/IsoSurface3D)|V18
+B8|2026-06-16|#469 FE `preserveSubtreeKeys` ≠ backend `_PRESERVE_SUBTREE_KEYS` (missing distribution(s)/output_var_selection/slider_values; extra default_inputs) → variable-name keys mangled, breaks V13/V14 one direction|V19
+B9|2026-06-16|#469 `functionUtils` preserve sets list camelCase `defaultInputs`/`gridData` but membership tested vs `camelToSnakeCase(rawKey)` (snake form) → unreachable dead entries|V19


### PR DESCRIPTION
## Summary
Governance-only SPEC update (no code) capturing the review feedback on the three re-port PRs so it is **not forgotten**. Companion to #467 / #468 / #469.

### What it records
- **node `§C` conventions** — structural rules surfaced by `alexpargon`'s review on #456 and his fix commit [`0811bcb`](https://github.com/ITISFoundation/mmux_vite/commit/0811bcb9f5be2d25e08c32733854813ee0f33c46): pure utilities live in `utils/` regardless of consumer count; shared helpers single-sourced + exported; test data under `__fixtures__/`; component internal ordering (theme → context → derived → state → ref → handlers → effects → layout → JSX).
- **`§B` bugs + `§V` invariants (via /backprop)** — every unresolved Copilot review finding on #467/#468/#469, each with a testable invariant that would catch recurrence:
  - flaskapi `§B1–B5` → `§V17–V20` (local-store path, `jobIds`/`job_ids` serializer collision, unconditional local merges vs V15, `_parse_number` data corruption, `_load_store` silent wipe)
  - node `§B6–B9` → `§V17–V19` (`lastSavedContent` on failed save, `lastFetchedKey` cached pre-resolve, FE/BE preserve-key set mismatch, dead camelCase entries)
- **`§T` fix-tasks** — flaskapi `§T10–T14`, node `§T11–T13`, plus node `§T14` carrying the literal `0811bcb` fixes into the future wave-2 node PRs (csv/local-functions/logscale) so they aren't lost.
- **root `§T7`** — review-backprop tracker; notes the three PRs are rebased onto `develop` and **must not merge before their `§T` fixes are addressed**.

### Notes
- Per the backprop protocol, invariants here are recorded with their fix-tasks; the **code fixes + invariant-citing tests land with the §T tasks** (deferred), not in this docs commit.
- No production code touched; pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)