### PR TITLE
feat(node): add sensitivity analysis views

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -30,6 +30,7 @@
         "@playwright/test": "^1.61.0",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.3",
         "@types/node": "^22.14.1",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
@@ -564,16 +565,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/core": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
@@ -589,6 +580,16 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
       "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2711,6 +2712,20 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
+      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -3674,7 +3689,6 @@
       "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@blazediff/core": "1.9.1",
         "@vitest/mocker": "4.1.10",
@@ -9935,6 +9949,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12783,7 +12798,6 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",

--- a/node/package.json
+++ b/node/package.json
@@ -38,6 +38,7 @@
     "@playwright/test": "^1.61.0",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.3",
     "@types/node": "^22.14.1",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",

--- a/node/src/components/plots/CorrelationIndicesPlot.tsx
+++ b/node/src/components/plots/CorrelationIndicesPlot.tsx
@@ -1,0 +1,227 @@
+import { Box, ToggleButton, ToggleButtonGroup, useTheme } from "@mui/material";
+import { useEffect, useState } from "react";
+import Plot from "react-plotly.js";
+import { useFunctionContext } from "../../context/FunctionContext";
+import { useJobContext } from "../../context/JobContext";
+import { useMMUXContext } from "../../context/MMUXContext";
+import {
+  correlationAbsLogRange,
+  correlationLinearRange,
+  correlationSymlogRange,
+  symlogTicks,
+  symlogTransform,
+  type CorrelationScaleType,
+} from "../../utils/plotScale";
+import { fetchCorrelationIndices } from "../../utils/correlationIndices";
+import CalculatingWarning from "./CalculatingWarning";
+import InsufficientDataWarning from "./InsufficientDataWarning";
+
+type CorrelationViewMode = "pearson" | "spearman";
+
+// #470: single-plot sensitivity view — one bar per input variable, toggling between
+// Pearson and Spearman correlation strength to the selected QoI (beyond the current
+// 3-var 1D/2D/3D plot limit).
+export default function CorrelationIndicesPlot() {
+  const theme = useTheme();
+  const { selectedFunction, inputVars, distribution } = useFunctionContext();
+  const { numSamples, selectedQoI } = useMMUXContext();
+  const { fetchedJobCollections, filteredJobList } = useJobContext();
+  const [correlations, setCorrelations] = useState<CorrelationIndicesResponse["correlations"] | null>(null);
+  const [plotData, setPlotData] = useState<Plotly.Data[]>([]);
+  const [computing, setComputing] = useState(false);
+  const [viewMode, setViewMode] = useState<CorrelationViewMode>("pearson");
+  const [scaleType, setScaleType] = useState<CorrelationScaleType>("abslog");
+
+  useEffect(() => {
+    (async () => {
+      setCorrelations(null);
+      setPlotData([]);
+      setComputing(true);
+      if (filteredJobList.length === 0 || !selectedQoI) {
+        console.warn("No jobs selected for correlation indices computation.");
+        setComputing(false);
+        return;
+      }
+      try {
+        const data = await fetchCorrelationIndices({
+          inputVars,
+          output: selectedQoI,
+          distributions: distribution[selectedFunction?.uid || ""],
+          functionJobs: filteredJobList,
+          numSamples: numSamples[selectedFunction?.uid || ""] || 10000,
+          seed: 0,
+        });
+        setCorrelations(data.correlations);
+        setComputing(false);
+      } catch (error) {
+        console.warn("Error computing correlation indices:", error);
+        setComputing(false);
+        setCorrelations(null);
+      }
+    })();
+  }, [filteredJobList, selectedQoI, numSamples, inputVars, distribution, selectedFunction]);
+
+  useEffect(() => {
+    if (!correlations) {
+      setPlotData([]);
+      return;
+    }
+    const rawValues = inputVars.map(inputVar => correlations[inputVar]?.[viewMode] ?? 0);
+
+    if (scaleType === "abslog") {
+      // Sign is dropped from the axis (log can't represent it), so we split into two
+      // traces colored by sign instead — lets magnitudes be compared directly even
+      // across opposite-sign variables, with the sign recovered via color + legend.
+      const positive: { x: string[]; y: number[]; raw: number[] } = { x: [], y: [], raw: [] };
+      const negative: { x: string[]; y: number[]; raw: number[] } = { x: [], y: [], raw: [] };
+      inputVars.forEach((inputVar, i) => {
+        const raw = rawValues[i];
+        const bucket = raw >= 0 ? positive : negative;
+        bucket.x.push(inputVar);
+        bucket.y.push(Math.abs(raw));
+        bucket.raw.push(raw);
+      });
+      setPlotData([
+        {
+          x: positive.x,
+          y: positive.y,
+          customdata: positive.raw,
+          type: "bar",
+          name: "Positive",
+          marker: { color: theme.palette.primary.main },
+          hovertemplate: "%{x}: %{customdata:.4f}<extra></extra>",
+        },
+        {
+          x: negative.x,
+          y: negative.y,
+          customdata: negative.raw,
+          type: "bar",
+          name: "Negative",
+          marker: { color: theme.palette.secondary.main },
+          hovertemplate: "%{x}: %{customdata:.4f}<extra></extra>",
+        },
+      ]);
+      return;
+    }
+
+    const values = scaleType === "symlog" ? rawValues.map(symlogTransform) : rawValues;
+    const color = viewMode === "pearson" ? theme.palette.primary.main : theme.palette.secondary.main;
+    setPlotData([
+      {
+        x: inputVars,
+        y: values,
+        customdata: rawValues,
+        type: "bar",
+        name: viewMode === "pearson" ? "Pearson" : "Spearman",
+        marker: { color },
+        hovertemplate: "%{x}: %{customdata:.4f}<extra></extra>",
+      },
+    ]);
+  }, [correlations, viewMode, scaleType, inputVars, theme.palette.primary.main, theme.palette.secondary.main]);
+
+  const handleViewModeChange = (_event: React.MouseEvent<HTMLElement>, newMode: CorrelationViewMode | null) => {
+    if (newMode !== null) {
+      setViewMode(newMode);
+    }
+  };
+
+  const handleScaleTypeChange = (_event: React.MouseEvent<HTMLElement>, newScale: CorrelationScaleType | null) => {
+    if (newScale !== null) {
+      setScaleType(newScale);
+    }
+  };
+
+  const symlogAxis = symlogTicks();
+  const gridStyle = { showgrid: true, gridcolor: theme.palette.divider };
+  const minorGridStyle = { showgrid: true, gridcolor: theme.palette.divider, gridwidth: 0.5 };
+  let yaxis: Partial<Plotly.LayoutAxis>;
+  if (scaleType === "symlog") {
+    yaxis = {
+      title: { text: "Correlation coefficient (symlog)" },
+      range: correlationSymlogRange,
+      tickvals: symlogAxis.tickvals,
+      ticktext: symlogAxis.ticktext,
+      ...gridStyle,
+      minor: { ...minorGridStyle, dtick: 0.1 },
+    };
+  } else if (scaleType === "abslog") {
+    yaxis = {
+      title: { text: "|Correlation coefficient| (log)" },
+      type: "log",
+      range: correlationAbsLogRange,
+      ...gridStyle,
+      minor: minorGridStyle,
+    };
+  } else {
+    yaxis = {
+      title: { text: "Correlation coefficient" },
+      range: correlationLinearRange,
+      ...gridStyle,
+      minor: { ...minorGridStyle, dtick: 0.1 },
+    };
+  }
+  const layout = {
+    title: { text: "Sensitivity / Correlation Indices" },
+    // fixed category order needed for abslog's two sign-split traces to line up correctly
+    // (each only covers a subset of inputVars, in varying orders otherwise)
+    xaxis: { title: { text: "Input variable" }, categoryorder: "array" as const, categoryarray: inputVars },
+    yaxis,
+    barmode: "group" as const,
+    plot_bgcolor: `${theme.palette.background.default}`,
+    paper_bgcolor: `${theme.palette.background.default}`,
+    font: { color: `${theme.palette.text.primary}` },
+  };
+  const plotStyle = {
+    width: "100%",
+    height: 400,
+    borderRadius: "8px",
+    overflow: "hidden",
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" gap={1} width="100%">
+      <Box display="flex" justifyContent="flex-end" gap={1}>
+        <ToggleButtonGroup
+          value={viewMode}
+          exclusive
+          onChange={handleViewModeChange}
+          size="small"
+          mmux-testid="correlation-view-toggle"
+        >
+          <ToggleButton value="pearson" sx={{ textTransform: "none" }} mmux-testid="correlation-toggle-pearson">
+            Pearson
+          </ToggleButton>
+          <ToggleButton value="spearman" sx={{ textTransform: "none" }} mmux-testid="correlation-toggle-spearman">
+            Spearman
+          </ToggleButton>
+        </ToggleButtonGroup>
+        <ToggleButtonGroup
+          value={scaleType}
+          exclusive
+          onChange={handleScaleTypeChange}
+          size="small"
+          mmux-testid="correlation-scale-toggle"
+        >
+          <ToggleButton value="linear" sx={{ textTransform: "none" }} mmux-testid="correlation-scale-linear">
+            Linear
+          </ToggleButton>
+          {/* symlog hidden per user feedback (T43) — abslog covers the "compare magnitudes" use
+              case better; symlogTransform/symlogTicks kept for potential future re-use */}
+          <ToggleButton value="abslog" sx={{ textTransform: "none" }} mmux-testid="correlation-scale-abslog">
+            Log
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+      {computing && <CalculatingWarning height={plotStyle.height} dontShowText={plotData.length !== 0} />}
+      {!computing && plotData.length === 0 && (
+        <InsufficientDataWarning
+          fetchedJobCollections={fetchedJobCollections}
+          filteredJobList={filteredJobList}
+          height={plotStyle.height}
+          numInputVars={inputVars.length}
+        />
+      )}
+      {!computing && plotData.length !== 0 && <Plot data={plotData} layout={layout} style={plotStyle} />}
+    </Box>
+  );
+}

--- a/node/src/components/plots/SobolIndicesPlot.test.tsx
+++ b/node/src/components/plots/SobolIndicesPlot.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildSobolBarData, buildSobolHeatmapData } from "../../utils/sobolIndices";
+
+vi.mock("../../utils/sobolIndices", async importOriginal => {
+  const mod = await importOriginal<typeof import("../../utils/sobolIndices")>();
+  return mod;
+});
+
+describe("SobolIndicesPlot toggle helpers", () => {
+  const getZ = (trace: ReturnType<typeof buildSobolHeatmapData>): number[][] => trace.z as number[][];
+  const sobol = {
+    x1: { main: 0.5, total: 0.7, mainCiLow: 0.5, mainCiHigh: 0.5, totalCiLow: 0.7, totalCiHigh: 0.7 },
+    x2: { main: 0.3, total: 0.5, mainCiLow: 0.3, mainCiHigh: 0.3, totalCiLow: 0.5, totalCiHigh: 0.5 },
+  };
+  const sobolSecondOrder = {
+    x1: { x2: 0.1 },
+    x2: { x1: 0.1 },
+  };
+
+  it("first-order: buildSobolBarData returns a single Main-effect trace", () => {
+    const traces = buildSobolBarData(sobol, ["x1", "x2"], { main: "#aaa", total: "#bbb" });
+    expect(traces).toHaveLength(2);
+    expect(traces[0]).toMatchObject({ name: "Main effect" });
+  });
+
+  it("total-order: buildSobolBarData returns a Total-effect trace", () => {
+    const traces = buildSobolBarData(sobol, ["x1", "x2"], { main: "#aaa", total: "#bbb" });
+    expect(traces[1]).toMatchObject({ name: "Total effect" });
+  });
+
+  it("second-order: buildSobolHeatmapData returns a heatmap trace", () => {
+    const trace = buildSobolHeatmapData(sobol, sobolSecondOrder, ["x1", "x2"]);
+    expect(trace.type).toBe("heatmap");
+    expect(trace.z).toHaveLength(2);
+  });
+
+  it("second-order: diagonal cells contain first-order values", () => {
+    const trace = buildSobolHeatmapData(sobol, sobolSecondOrder, ["x1", "x2"]);
+    expect(getZ(trace)[0][0]).toBe(0.5);
+    expect(getZ(trace)[1][1]).toBe(0.3);
+  });
+
+  it("second-order: off-diagonal cells contain pairwise second-order values", () => {
+    const trace = buildSobolHeatmapData(sobol, sobolSecondOrder, ["x1", "x2"]);
+    expect(getZ(trace)[0][1]).toBe(0.1);
+    expect(getZ(trace)[1][0]).toBe(0.1);
+  });
+});

--- a/node/src/components/plots/SobolIndicesPlot.tsx
+++ b/node/src/components/plots/SobolIndicesPlot.tsx
@@ -1,0 +1,192 @@
+import { Box, ToggleButton, ToggleButtonGroup, useTheme } from "@mui/material";
+import { useEffect, useState } from "react";
+import Plot from "react-plotly.js";
+import { useFunctionContext } from "../../context/FunctionContext";
+import { useJobContext } from "../../context/JobContext";
+import { useMMUXContext } from "../../context/MMUXContext";
+import { sobolLinearRange, sobolLogRange, toLogSafe, type ScaleType } from "../../utils/plotScale";
+import { buildSobolHeatmapData, fetchSobolIndices } from "../../utils/sobolIndices";
+import CalculatingWarning from "./CalculatingWarning";
+import InsufficientDataWarning from "./InsufficientDataWarning";
+
+type SobolViewMode = "first-order" | "total-order" | "second-order";
+
+export default function SobolIndicesPlot() {
+  const theme = useTheme();
+  const { selectedFunction, inputVars, distribution } = useFunctionContext();
+  const { numSamples, selectedQoI } = useMMUXContext();
+  const { fetchedJobCollections, filteredJobList } = useJobContext();
+  const [sobolData, setSobolData] = useState<SobolIndicesResponse | null>(null);
+  const [plotData, setPlotData] = useState<Plotly.Data[]>([]);
+  const [computing, setComputing] = useState(false);
+  const [viewMode, setViewMode] = useState<SobolViewMode>("first-order");
+  const [scaleType, setScaleType] = useState<ScaleType>("log");
+
+  useEffect(() => {
+    (async () => {
+      setSobolData(null);
+      setPlotData([]);
+      setComputing(true);
+      if (filteredJobList.length === 0 || !selectedQoI) {
+        console.warn("No jobs selected for Sobol' indices computation.");
+        setComputing(false);
+        return;
+      }
+      try {
+        const data = await fetchSobolIndices({
+          inputVars,
+          output: selectedQoI,
+          distributions: distribution[selectedFunction?.uid || ""],
+          functionJobs: filteredJobList,
+          numSamples: numSamples[selectedFunction?.uid || ""] || 10000,
+          seed: 0,
+        });
+        setSobolData(data);
+        setComputing(false);
+      } catch (error) {
+        console.warn("Error computing Sobol' indices:", error);
+        setComputing(false);
+        setSobolData(null);
+      }
+    })();
+  }, [filteredJobList, selectedQoI, numSamples, inputVars, distribution, selectedFunction]);
+
+  useEffect(() => {
+    if (!sobolData) {
+      setPlotData([]);
+      return;
+    }
+    const { sobol, sobolSecondOrder } = sobolData;
+
+    if (viewMode === "first-order") {
+      const mainValues = inputVars.map(v => sobol[v]?.main ?? 0);
+      const ciHighDelta = inputVars.map(v => Math.max(0, (sobol[v]?.mainCiHigh ?? sobol[v]?.main ?? 0) - (sobol[v]?.main ?? 0)));
+      const ciLowDelta = inputVars.map(v => Math.max(0, (sobol[v]?.main ?? 0) - (sobol[v]?.mainCiLow ?? sobol[v]?.main ?? 0)));
+      setPlotData([
+        {
+          x: inputVars,
+          y: mainValues,
+          type: "bar",
+          name: "First order",
+          marker: { color: theme.palette.primary.main },
+          error_y: { type: "data", symmetric: false, array: ciHighDelta, arrayminus: ciLowDelta },
+        },
+      ]);
+    } else if (viewMode === "total-order") {
+      const totalValues = inputVars.map(v => sobol[v]?.total ?? 0);
+      const ciHighDelta = inputVars.map(v =>
+        Math.max(0, (sobol[v]?.totalCiHigh ?? sobol[v]?.total ?? 0) - (sobol[v]?.total ?? 0)),
+      );
+      const ciLowDelta = inputVars.map(v => Math.max(0, (sobol[v]?.total ?? 0) - (sobol[v]?.totalCiLow ?? sobol[v]?.total ?? 0)));
+      setPlotData([
+        {
+          x: inputVars,
+          y: totalValues,
+          type: "bar",
+          name: "Total order",
+          marker: { color: theme.palette.secondary.main },
+          error_y: { type: "data", symmetric: false, array: ciHighDelta, arrayminus: ciLowDelta },
+        },
+      ]);
+    } else {
+      // second-order heatmap: log scale applies to the color axis, not a value axis
+      const heatmap = buildSobolHeatmapData(sobol, sobolSecondOrder, inputVars);
+      if (scaleType === "log") {
+        const z = (heatmap.z as number[][]).map(row => row.map(toLogSafe));
+        setPlotData([{ ...heatmap, z, zmin: sobolLogRange[0], zmax: sobolLogRange[1] }]);
+      } else {
+        setPlotData([{ ...heatmap, zmin: sobolLinearRange[0], zmax: sobolLinearRange[1] }]);
+      }
+    }
+  }, [sobolData, viewMode, scaleType, inputVars, theme.palette.primary.main, theme.palette.secondary.main]);
+
+  const handleViewModeChange = (_event: React.MouseEvent<HTMLElement>, newMode: SobolViewMode | null) => {
+    if (newMode !== null) {
+      setViewMode(newMode);
+    }
+  };
+
+  const handleScaleTypeChange = (_event: React.MouseEvent<HTMLElement>, newScale: ScaleType | null) => {
+    if (newScale !== null) {
+      setScaleType(newScale);
+    }
+  };
+
+  const isHeatmap = viewMode === "second-order";
+  const layout = isHeatmap
+    ? {
+        title: { text: "Sobol' Indices" },
+        xaxis: { title: { text: "Variable" }, side: "bottom" as const },
+        yaxis: { title: { text: "Variable" }, autorange: "reversed" as const },
+        plot_bgcolor: `${theme.palette.background.default}`,
+        paper_bgcolor: `${theme.palette.background.default}`,
+        font: { color: `${theme.palette.text.primary}` },
+      }
+    : {
+        title: { text: "Sobol' Indices" },
+        xaxis: { title: { text: "Input variable" } },
+        yaxis: {
+          title: { text: "Sobol' index" },
+          type: scaleType,
+          range: scaleType === "log" ? sobolLogRange : sobolLinearRange,
+        },
+        barmode: "group" as const,
+        plot_bgcolor: `${theme.palette.background.default}`,
+        paper_bgcolor: `${theme.palette.background.default}`,
+        font: { color: `${theme.palette.text.primary}` },
+      };
+  const plotStyle = {
+    width: "100%",
+    height: 400,
+    borderRadius: "8px",
+    overflow: "hidden",
+  };
+
+  return (
+    <Box display="flex" flexDirection="column" gap={1} width="100%">
+      <Box display="flex" justifyContent="flex-end" gap={1}>
+        <ToggleButtonGroup
+          value={viewMode}
+          exclusive
+          onChange={handleViewModeChange}
+          size="small"
+          mmux-testid="sobol-view-toggle"
+        >
+          <ToggleButton value="first-order" sx={{ textTransform: "none" }} mmux-testid="sobol-toggle-first">
+            First order
+          </ToggleButton>
+          <ToggleButton value="second-order" sx={{ textTransform: "none" }} mmux-testid="sobol-toggle-second">
+            Second order
+          </ToggleButton>
+          <ToggleButton value="total-order" sx={{ textTransform: "none" }} mmux-testid="sobol-toggle-total">
+            Total order
+          </ToggleButton>
+        </ToggleButtonGroup>
+        <ToggleButtonGroup
+          value={scaleType}
+          exclusive
+          onChange={handleScaleTypeChange}
+          size="small"
+          mmux-testid="sobol-scale-toggle"
+        >
+          <ToggleButton value="linear" sx={{ textTransform: "none" }} mmux-testid="sobol-scale-linear">
+            Linear
+          </ToggleButton>
+          <ToggleButton value="log" sx={{ textTransform: "none" }} mmux-testid="sobol-scale-log">
+            Log
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
+      {computing && <CalculatingWarning height={plotStyle.height} dontShowText={plotData.length !== 0} />}
+      {!computing && !sobolData && (
+        <InsufficientDataWarning
+          fetchedJobCollections={fetchedJobCollections}
+          filteredJobList={filteredJobList}
+          height={plotStyle.height}
+          numInputVars={inputVars.length}
+        />
+      )}
+      {!computing && plotData.length !== 0 && <Plot data={plotData} layout={layout} style={plotStyle} />}
+    </Box>
+  );
+}

--- a/node/src/components/plots/SteppedPlotCard.test.tsx
+++ b/node/src/components/plots/SteppedPlotCard.test.tsx
@@ -1,0 +1,118 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SteppedPlotCard, { type SteppedStep } from "./SteppedPlotCard";
+
+const makeSteps = (count: number): SteppedStep[] =>
+  Array.from({ length: count }, (_, i) => ({
+    title: `Step ${i + 1}`,
+    content: <div data-testid={`content-${i + 1}`}>Content for step {i + 1}</div>,
+  }));
+
+describe("SteppedPlotCard", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("renders the active step title", () => {
+    render(<SteppedPlotCard steps={makeSteps(3)} activeStep={0} maxSteps={3} onNext={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByText("Step 1")).toBeDefined();
+  });
+
+  it("renders the active step content", () => {
+    render(<SteppedPlotCard steps={makeSteps(3)} activeStep={1} maxSteps={3} onNext={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByTestId("content-2")).toBeDefined();
+    expect(screen.queryByTestId("content-1")).toBeNull();
+  });
+
+  it("calls onNext when Next button is clicked", async () => {
+    const onNext = vi.fn();
+    render(<SteppedPlotCard steps={makeSteps(3)} activeStep={0} maxSteps={3} onNext={onNext} onBack={vi.fn()} />);
+    await userEvent.click(screen.getByText("Next"));
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onBack when Back button is clicked", async () => {
+    const onBack = vi.fn();
+    render(<SteppedPlotCard steps={makeSteps(3)} activeStep={1} maxSteps={3} onNext={vi.fn()} onBack={onBack} />);
+    await userEvent.click(screen.getByText("Back"));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Back on first step", () => {
+    render(<SteppedPlotCard steps={makeSteps(3)} activeStep={0} maxSteps={3} onNext={vi.fn()} onBack={vi.fn()} />);
+    const backButton = screen.getByText("Back").closest("button");
+    expect(backButton).toHaveProperty("disabled", true);
+  });
+
+  it("disables Next on last step", () => {
+    render(<SteppedPlotCard steps={makeSteps(3)} activeStep={2} maxSteps={3} onNext={vi.fn()} onBack={vi.fn()} />);
+    const nextButton = screen.getByText("Next").closest("button");
+    expect(nextButton).toHaveProperty("disabled", true);
+  });
+
+  it("renders qoiSelector when provided", () => {
+    render(
+      <SteppedPlotCard
+        steps={makeSteps(2)}
+        activeStep={0}
+        maxSteps={2}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+        qoiSelector={<div data-testid="qoi-selector">QoI Selector</div>}
+      />,
+    );
+    expect(screen.getByTestId("qoi-selector")).toBeDefined();
+  });
+
+  it("updates title and content when activeStep changes", () => {
+    const { rerender } = render(
+      <SteppedPlotCard
+        steps={[
+          { title: "First", content: <div data-testid="content-1">First content</div> },
+          { title: "Second", content: <div data-testid="content-2">Second content</div> },
+          { title: "Third", content: <div data-testid="content-3">Third content</div> },
+        ]}
+        activeStep={0}
+        maxSteps={3}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("First")).toBeDefined();
+    expect(screen.getByTestId("content-1")).toBeDefined();
+
+    rerender(
+      <SteppedPlotCard
+        steps={[
+          { title: "First", content: <div data-testid="content-1">First content</div> },
+          { title: "Second", content: <div data-testid="content-2">Second content</div> },
+          { title: "Third", content: <div data-testid="content-3">Third content</div> },
+        ]}
+        activeStep={1}
+        maxSteps={3}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Second")).toBeDefined();
+    expect(screen.getByTestId("content-2")).toBeDefined();
+    expect(screen.queryByTestId("content-1")).toBeNull();
+  });
+
+  it("passes custom testids to buttons", () => {
+    const { container } = render(
+      <SteppedPlotCard
+        steps={makeSteps(2)}
+        activeStep={0}
+        maxSteps={2}
+        onNext={vi.fn()}
+        onBack={vi.fn()}
+        nextTestId="custom-next"
+        backTestId="custom-back"
+      />,
+    );
+    expect(container.querySelector('[mmux-testid="custom-next"]')).not.toBeNull();
+    expect(container.querySelector('[mmux-testid="custom-back"]')).not.toBeNull();
+  });
+});

--- a/node/src/components/plots/SteppedPlotCard.tsx
+++ b/node/src/components/plots/SteppedPlotCard.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { Box, Button, Card, CardActions, CardContent, MobileStepper, useTheme } from "@mui/material";
+import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
+import Header from "../navigation/Header";
+
+export type SteppedStep = {
+  title: string;
+  infoText?: string;
+  extendedInfoText?: React.ReactElement;
+  content: React.ReactNode;
+};
+
+export type SteppedPlotCardProps = {
+  steps: SteppedStep[];
+  activeStep: number;
+  maxSteps: number;
+  onNext: () => void;
+  onBack: () => void;
+  headerType?: HeaderTypes;
+  qoiSelector?: React.ReactNode;
+  nextTestId?: string;
+  backTestId?: string;
+  /** Reserves space for the content slot so steps of varying height don't shift the Next/Back buttons. */
+  contentMinHeight?: number | string;
+};
+
+function SteppedPlotCard(props: SteppedPlotCardProps) {
+  const { steps, activeStep, maxSteps, onNext, onBack, headerType, qoiSelector, nextTestId, backTestId, contentMinHeight } =
+    props;
+  const theme = useTheme();
+  const currentStep = steps[activeStep];
+
+  return (
+    <Card
+      sx={{
+        overflow: "auto",
+        backgroundImage: "none",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+        }}
+      >
+        <Header
+          headerType={headerType || "titleNoMargin"}
+          tabTitle={currentStep?.title}
+          infoText={currentStep?.infoText}
+          extendedInfoText={currentStep?.extendedInfoText}
+          qoiSelector={qoiSelector}
+        />
+      </Box>
+      <CardContent
+        sx={{
+          padding: 0,
+          margin: "16px 0px",
+          borderRadius: theme.spacing(2),
+          overflow: "hidden",
+          minHeight: contentMinHeight,
+        }}
+      >
+        {currentStep?.content}
+      </CardContent>
+      <CardActions sx={{ padding: 0 }}>
+        <MobileStepper
+          variant="dots"
+          steps={maxSteps}
+          position="static"
+          activeStep={activeStep}
+          sx={{
+            maxWidth: 400,
+            flexGrow: 1,
+            margin: "0px auto",
+            borderRadius: 2,
+            backgroundColor: theme.palette.background.default,
+          }}
+          nextButton={
+            <Button
+              size="small"
+              variant="contained"
+              onClick={onNext}
+              disabled={activeStep === maxSteps - 1}
+              sx={{ alignItems: "end" }}
+              mmux-testid={nextTestId || "stepped-plot-next"}
+            >
+              Next
+              {theme.direction === "rtl" ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
+            </Button>
+          }
+          backButton={
+            <Button
+              size="small"
+              variant="contained"
+              onClick={onBack}
+              disabled={activeStep === 0}
+              sx={{ alignItems: "end" }}
+              mmux-testid={backTestId || "stepped-plot-back"}
+            >
+              {theme.direction === "rtl" ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
+              Back
+            </Button>
+          }
+        />
+      </CardActions>
+    </Card>
+  );
+}
+
+export default SteppedPlotCard;

--- a/node/src/components/plots/SuMoPlotsSteps.tsx
+++ b/node/src/components/plots/SuMoPlotsSteps.tsx
@@ -1,22 +1,11 @@
 import React from "react";
-import {
-  Box,
-  Button,
-  Card,
-  CardActions,
-  CardContent,
-  InputLabel,
-  MenuItem,
-  MobileStepper,
-  Select,
-  useTheme,
-} from "@mui/material";
-import { InfoOutline, KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
+import { Box, InputLabel, MenuItem, Select, useTheme } from "@mui/material";
+import { InfoOutline } from "@mui/icons-material";
 import IsoSurface3DPlot from "./IsoSurface3DPlot";
 import Curves1DPlots from "./Curves1DPlot";
 import SuMoValidation from "./SuMoValidation";
 import Surface2DPlot from "./Surface2DPlot";
-import Header from "../navigation/Header";
+import SteppedPlotCard, { type SteppedStep } from "./SteppedPlotCard";
 import { filterInputVars } from "./PlotTools";
 import CrossValidationDocument from "../documents/CrossValidationDocument";
 import { useFunctionContext } from "../../context/FunctionContext";
@@ -44,21 +33,17 @@ function SuMoPlotsSteps() {
     setActiveStep(prevActiveStep => prevActiveStep - 1);
   };
 
-  const stepTitles = ["Validation", "1D Curves", "2D Surface", "3D IsoSurface"];
-  const stepInfoTexts: { [key: string]: string | undefined } = {
-    Validation: "Assessment of model quality through Cross-Validation ",
-    "1D Curves": undefined,
-    "2D Surface": undefined,
-    "3D IsoSurface": undefined,
-  };
-  const stepExtendedInfoTexts: {
-    [key: string]: React.ReactElement | undefined;
-  } = {
-    Validation: CrossValidationDocument,
-    "1D Curves": undefined,
-    "2D Surface": undefined,
-    "3D IsoSurface": undefined,
-  };
+  const stepDefinitions: SteppedStep[] = [
+    {
+      title: "Validation",
+      infoText: "Assessment of model quality through Cross-Validation",
+      extendedInfoText: CrossValidationDocument,
+      content: <SuMoValidation />,
+    },
+    { title: "1D Curves", content: <Curves1DPlots /> },
+    { title: "2D Surface", content: <Surface2DPlot /> },
+    { title: "3D IsoSurface", content: <IsoSurface3DPlot /> },
+  ];
 
   React.useEffect(() => {
     const jobs = filteredJobList;
@@ -68,138 +53,86 @@ function SuMoPlotsSteps() {
     } else {
       setFilteredInputVars(filterInputVars({ ...context, selectedFunction, inputVars, distribution }));
     }
-    setMaxSteps(Math.min(filteredInputVars.length + 1, stepTitles.length));
+    setMaxSteps(Math.min(filteredInputVars.length + 1, stepDefinitions.length));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedJobUids, filteredJobList]);
 
+  const visibleSteps = stepDefinitions.slice(0, maxSteps);
+  const gatedContent = (() => {
+    if (filteredInputVars.length === 0) return undefined;
+    const minVars = activeStep <= 1 ? 0 : activeStep - 1;
+    if (filteredInputVars.length <= minVars) return undefined;
+    return visibleSteps[activeStep]?.content;
+  })();
+
+  const stepsWithGatedContent = visibleSteps.map((step, i) => ({
+    ...step,
+    content: i === activeStep ? gatedContent : step.content,
+  }));
+
   return (
-    <Card
-      sx={{
-        overflow: "auto",
-        backgroundImage: "none",
-      }}
-    >
-      <Box
-        sx={{
-          display: "flex",
-          alignItems: "center",
-        }}
-      >
-        <Header
-          headerType="titleNoMargin"
-          tabTitle={stepTitles[activeStep]}
-          infoText={stepInfoTexts[stepTitles[activeStep]]}
-          extendedInfoText={stepExtendedInfoTexts[stepTitles[activeStep]]}
-          qoiSelector={
-            (serviceMode === "MOGA" || serviceMode === "UQ") && (
-              <InputLabel
-                size="small"
-                sx={{
-                  display: "flex",
-                  flex: 1,
-                  transform: "none",
-                  alignItems: "baseline",
-                  gap: "8px",
-                  fontFamily: "inherit",
-                  fontWeight: 300,
-                  fontSize: "1.2em",
-                }}
+    <SteppedPlotCard
+      steps={stepsWithGatedContent}
+      activeStep={activeStep}
+      maxSteps={maxSteps}
+      onNext={handleNext}
+      onBack={handleBack}
+      nextTestId="sumo-plot-next"
+      backTestId="sumo-plot-back"
+      qoiSelector={
+        (serviceMode === "MOGA" || serviceMode === "UQ") && (
+          <InputLabel
+            size="small"
+            sx={{
+              display: "flex",
+              flex: 1,
+              transform: "none",
+              alignItems: "baseline",
+              gap: "8px",
+              fontFamily: "inherit",
+              fontWeight: 300,
+              fontSize: "1.2em",
+            }}
+          >
+            <Box sx={{ display: "flex", alignItems: "center" }}>
+              Select Quantity of Interest
+              <CustomTooltip
+                title="Choose the simulation output to analyze"
+                extendedTooltip={SelectQoIDocument}
+                placement="right"
+                arrow
               >
-                <Box sx={{ display: "flex", alignItems: "center" }}>
-                  Select Quantity of Interest
-                  <CustomTooltip
-                    title="Choose the simulation output to analyze"
-                    extendedTooltip={SelectQoIDocument}
-                    placement="right"
-                    arrow
-                  >
-                    <InfoOutline
-                      sx={{
-                        color: theme.palette.primary.light,
-                        backgroundColor: theme.palette.background.default,
-                        borderRadius: "50%",
-                        padding: "2px",
-                        marginLeft: "4px",
-                      }}
-                    />
-                  </CustomTooltip>
-                </Box>
-                <Select
-                  size="small"
-                  variant="outlined"
-                  sx={{ flex: 1 }}
-                  value={selectedQoI || ""}
-                  onChange={e => {
-                    setSelectedQoI(e.target.value);
+                <InfoOutline
+                  sx={{
+                    color: theme.palette.primary.light,
+                    backgroundColor: theme.palette.background.default,
+                    borderRadius: "50%",
+                    padding: "2px",
+                    marginLeft: "4px",
                   }}
-                  mmux-testid="qoi-select"
-                >
-                  {outputVars.map(qoi => (
-                    <MenuItem key={`qoi-${qoi}`} value={qoi}>
-                      {qoi}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </InputLabel>
-            )
-          }
-        />
-      </Box>
-      <CardContent
-        sx={{
-          padding: 0,
-          margin: "16px 0px",
-          borderRadius: theme.spacing(2),
-          overflow: "hidden",
-        }}
-      >
-        {activeStep === 0 && filteredInputVars.length > 0 ? <SuMoValidation /> : undefined}
-        {activeStep === 1 && filteredInputVars.length > 0 ? <Curves1DPlots /> : undefined}
-        {activeStep === 2 && filteredInputVars.length > 1 ? <Surface2DPlot /> : undefined}
-        {activeStep === 3 && filteredInputVars.length > 2 ? <IsoSurface3DPlot /> : undefined}
-      </CardContent>
-      <CardActions sx={{ padding: 0 }}>
-        <MobileStepper
-          variant="dots"
-          steps={maxSteps}
-          position="static"
-          activeStep={activeStep}
-          sx={{
-            maxWidth: 400,
-            flexGrow: 1,
-            margin: "0px auto",
-            borderRadius: 2,
-            backgroundColor: theme.palette.background.default,
-          }}
-          nextButton={
-            <Button
+                />
+              </CustomTooltip>
+            </Box>
+            <Select
               size="small"
-              variant="contained"
-              onClick={handleNext}
-              disabled={activeStep === maxSteps - 1}
-              sx={{ alignItems: "end" }}
-              mmux-testid="sumo-plot-next"
+              variant="outlined"
+              sx={{ flex: 1 }}
+              value={selectedQoI || ""}
+              onChange={e => {
+                setSelectedQoI(e.target.value);
+              }}
+              mmux-testid="qoi-select"
             >
-              Next
-              {theme.direction === "rtl" ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
-            </Button>
-          }
-          backButton={
-            <Button
-              size="small"
-              variant="contained"
-              onClick={handleBack}
-              disabled={activeStep === 0}
-              sx={{ alignItems: "end" }}
-              mmux-testid="sumo-plot-back"
-            >
-              {theme.direction === "rtl" ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
-              Back
-            </Button>
-          }
-        />
-      </CardActions>
-    </Card>
+              {outputVars.map(qoi => (
+                <MenuItem key={`qoi-${qoi}`} value={qoi}>
+                  {qoi}
+                </MenuItem>
+              ))}
+            </Select>
+          </InputLabel>
+        )
+      }
+    />
   );
 }
 

--- a/node/src/components/plots/UQPlotsSteps.test.tsx
+++ b/node/src/components/plots/UQPlotsSteps.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import UQPlotsSteps from "./UQPlotsSteps";
+
+vi.mock("./UncertainUQ", () => ({
+  default: () => <div data-testid="uncertain-uq">UncertainUQ content</div>,
+}));
+
+vi.mock("./CorrelationIndicesPlot", () => ({
+  default: () => <div data-testid="correlation-plot">CorrelationIndicesPlot content</div>,
+}));
+
+vi.mock("./SobolIndicesPlot", () => ({
+  default: () => <div data-testid="sobol-plot">SobolIndicesPlot content</div>,
+}));
+
+const defaultProps = {
+  loading: false,
+  jobProgress: 0,
+  colsFetched: { current: 0 },
+  jobsFetched: { current: 0 },
+};
+
+describe("UQPlotsSteps", () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  it("renders 3 named step titles", () => {
+    render(<UQPlotsSteps {...defaultProps} />);
+    expect(screen.getByText("Histogram")).toBeDefined();
+    expect(screen.getByTestId("uncertain-uq")).toBeDefined();
+  });
+
+  it("shows Histogram content on first step", () => {
+    render(<UQPlotsSteps {...defaultProps} />);
+    expect(screen.getByTestId("uncertain-uq")).toBeDefined();
+    expect(screen.queryByTestId("correlation-plot")).toBeNull();
+    expect(screen.queryByTestId("sobol-plot")).toBeNull();
+  });
+
+  it("navigates to Correlation step on Next click", async () => {
+    render(<UQPlotsSteps {...defaultProps} />);
+    await userEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("Correlation")).toBeDefined();
+    expect(screen.getByTestId("correlation-plot")).toBeDefined();
+    expect(screen.queryByTestId("uncertain-uq")).toBeNull();
+    expect(screen.queryByTestId("sobol-plot")).toBeNull();
+  });
+
+  it("navigates to Sobol' step on second Next click", async () => {
+    render(<UQPlotsSteps {...defaultProps} />);
+    await userEvent.click(screen.getByText("Next"));
+    await userEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("Sobol' Indices")).toBeDefined();
+    expect(screen.getByTestId("sobol-plot")).toBeDefined();
+    expect(screen.queryByTestId("uncertain-uq")).toBeNull();
+    expect(screen.queryByTestId("correlation-plot")).toBeNull();
+  });
+
+  it("navigates back to previous step", async () => {
+    render(<UQPlotsSteps {...defaultProps} />);
+    await userEvent.click(screen.getByText("Next"));
+    expect(screen.getByTestId("correlation-plot")).toBeDefined();
+    await userEvent.click(screen.getByText("Back"));
+    expect(screen.getByTestId("uncertain-uq")).toBeDefined();
+    expect(screen.queryByTestId("correlation-plot")).toBeNull();
+  });
+
+  it("disables Back on first step", () => {
+    render(<UQPlotsSteps {...defaultProps} />);
+    const backButton = screen.getByText("Back").closest("button");
+    expect(backButton).toHaveProperty("disabled", true);
+  });
+
+  it("disables Next on last step (Sobol')", async () => {
+    render(<UQPlotsSteps {...defaultProps} />);
+    await userEvent.click(screen.getByText("Next"));
+    await userEvent.click(screen.getByText("Next"));
+    const nextButton = screen.getByText("Next").closest("button");
+    expect(nextButton).toHaveProperty("disabled", true);
+  });
+});

--- a/node/src/components/plots/UQPlotsSteps.tsx
+++ b/node/src/components/plots/UQPlotsSteps.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import SteppedPlotCard, { type SteppedStep } from "./SteppedPlotCard";
+import UncertainUQ from "./UncertainUQ";
+import CorrelationIndicesPlot from "./CorrelationIndicesPlot";
+import SobolIndicesPlot from "./SobolIndicesPlot";
+
+const uqStepTitles = ["Histogram", "Correlation", "Sobol' Indices"];
+
+const uqStepInfoTexts: Record<string, string | undefined> = {
+  Histogram: "Uncertainty propagation histogram with percentile statistics",
+  Correlation: undefined,
+  "Sobol' Indices": undefined,
+};
+
+type UQPlotsStepsProps = LoadingPropsType;
+
+function UQPlotsSteps(props: UQPlotsStepsProps) {
+  const { loading, jobProgress, colsFetched, jobsFetched } = props;
+  const [activeStep, setActiveStep] = React.useState(0);
+  const handleNext = () => {
+    setActiveStep(prev => prev + 1);
+  };
+  const handleBack = () => {
+    setActiveStep(prev => prev - 1);
+  };
+
+  const steps: SteppedStep[] = [
+    {
+      title: uqStepTitles[0],
+      infoText: uqStepInfoTexts[uqStepTitles[0]],
+      content: <UncertainUQ colsFetched={colsFetched} jobProgress={jobProgress} jobsFetched={jobsFetched} loading={loading} />,
+    },
+    { title: uqStepTitles[1], infoText: uqStepInfoTexts[uqStepTitles[1]], content: <CorrelationIndicesPlot /> },
+    { title: uqStepTitles[2], infoText: uqStepInfoTexts[uqStepTitles[2]], content: <SobolIndicesPlot /> },
+  ];
+
+  return (
+    <SteppedPlotCard
+      steps={steps}
+      activeStep={activeStep}
+      maxSteps={uqStepTitles.length}
+      onNext={handleNext}
+      onBack={handleBack}
+      contentMinHeight={500}
+      nextTestId="uq-plot-next"
+      backTestId="uq-plot-back"
+    />
+  );
+}
+
+export default UQPlotsSteps;

--- a/node/src/global.d.ts
+++ b/node/src/global.d.ts
@@ -42,6 +42,40 @@ type DataUQHistogramType = {
   max: number;
 };
 
+// #470: per-input <-> output correlation strength ({pearson,spearman} coefficients),
+// one entry per requested input variable, from `/flask/dakota/compute_correlation_indices`.
+type CorrelationCoefficients = {
+  pearson: number;
+  spearman: number;
+};
+
+type CorrelationIndicesResponse = {
+  correlations: { [inputVar: string]: CorrelationCoefficients };
+};
+
+// #470/#T22/T25: per-input first-order (main effect) and total-order Sobol'
+// sensitivity indices, one entry per requested input variable, from
+// `/flask/dakota/compute_sobol_indices` (scipy-based, post-migration).
+// `*CiLow`/`*CiHigh`: bootstrap confidence interval bounds (95%, T25) --
+// always present (backend computes them for free alongside the point
+// estimates), displayed as error bars on the first/total-order bar charts.
+// sobolSecondOrder: symmetric pairwise second-order indices (no self-pairs),
+// diagonal filled on frontend from the corresponding first-order index; no
+// CI display on the second-order heatmap (out of scope).
+type SobolIndexPair = {
+  main: number;
+  total: number;
+  mainCiLow: number;
+  mainCiHigh: number;
+  totalCiLow: number;
+  totalCiHigh: number;
+};
+
+type SobolIndicesResponse = {
+  sobol: { [inputVar: string]: SobolIndexPair };
+  sobolSecondOrder: { [varA: string]: { [varB: string]: number } };
+};
+
 type PlotConfig = {
   dimensionType: "1D" | "2D" | "3D";
   scaleType: "linear" | "log";

--- a/node/src/utils/correlationIndices.test.ts
+++ b/node/src/utils/correlationIndices.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OsparcFunctionJob } from "../context/types";
+import { fetchWithRetry } from "./fetchRetry";
+import { buildCorrelationBarData, fetchCorrelationIndices } from "./correlationIndices";
+
+vi.mock("./fetchRetry", () => ({
+  fetchWithRetry: vi.fn(),
+}));
+
+const mockedFetchWithRetry = vi.mocked(fetchWithRetry);
+
+const mockJobs: OsparcFunctionJob[] = [
+  { uid: "job1", functionUid: "func1", inputs: { x1: 1 }, outputs: { y: 2 }, status: "COMPLETED" },
+];
+
+beforeEach(() => {
+  mockedFetchWithRetry.mockReset();
+});
+
+describe("fetchCorrelationIndices", () => {
+  it("posts the expected payload and returns the parsed response on success", async () => {
+    const mockResponseBody: CorrelationIndicesResponse = {
+      correlations: {
+        x1: { pearson: 0.9, spearman: 0.85 },
+        x2: { pearson: -0.1, spearman: -0.05 },
+      },
+    };
+    mockedFetchWithRetry.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponseBody),
+    } as Response);
+
+    const result = await fetchCorrelationIndices({
+      inputVars: ["x1", "x2"],
+      output: "y",
+      distributions: { x1: { distribution: "uniform", min: 0, max: 1 } },
+      functionJobs: mockJobs,
+      numSamples: 500,
+      seed: 42,
+    });
+
+    expect(result).toEqual(mockResponseBody);
+    expect(mockedFetchWithRetry).toHaveBeenCalledWith(
+      "/flask/dakota/compute_correlation_indices",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const [, options] = mockedFetchWithRetry.mock.calls[0];
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body).toEqual({
+      inputVars: ["x1", "x2"],
+      output: "y",
+      distributions: { x1: { distribution: "uniform", min: 0, max: 1 } },
+      numSamples: 500,
+      FunctionJobs: mockJobs,
+      seed: 42,
+    });
+  });
+
+  it("defaults seed to 0 when not provided", async () => {
+    mockedFetchWithRetry.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ correlations: {} }),
+    } as Response);
+
+    await fetchCorrelationIndices({
+      inputVars: ["x1"],
+      output: "y",
+      distributions: {},
+      functionJobs: mockJobs,
+      numSamples: 100,
+    });
+
+    const [, options] = mockedFetchWithRetry.mock.calls[0];
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body.seed).toBe(0);
+  });
+
+  it("throws (⊥ resolves) on a non-OK response", async () => {
+    mockedFetchWithRetry.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve({}),
+    } as Response);
+
+    await expect(
+      fetchCorrelationIndices({
+        inputVars: ["x1"],
+        output: "y",
+        distributions: {},
+        functionJobs: mockJobs,
+        numSamples: 100,
+      }),
+    ).rejects.toThrow(/500/);
+  });
+});
+
+describe("buildCorrelationBarData", () => {
+  it("builds one Pearson trace and one Spearman trace, ordered by inputVars", () => {
+    const correlations: CorrelationIndicesResponse["correlations"] = {
+      x1: { pearson: 0.9, spearman: 0.8 },
+      x2: { pearson: -0.4, spearman: -0.3 },
+    };
+
+    const traces = buildCorrelationBarData(correlations, ["x1", "x2"], {
+      pearson: "#111111",
+      spearman: "#222222",
+    });
+
+    expect(traces).toHaveLength(2);
+    expect(traces[0]).toMatchObject({ x: ["x1", "x2"], y: [0.9, -0.4], name: "Pearson", type: "bar" });
+    expect(traces[1]).toMatchObject({ x: ["x1", "x2"], y: [0.8, -0.3], name: "Spearman", type: "bar" });
+  });
+
+  it("falls back to 0 for input variables missing from the correlations map", () => {
+    const traces = buildCorrelationBarData({ x1: { pearson: 0.5, spearman: 0.4 } }, ["x1", "x2"], {
+      pearson: "#111111",
+      spearman: "#222222",
+    });
+
+    expect(traces[0]).toMatchObject({ y: [0.5, 0] });
+    expect(traces[1]).toMatchObject({ y: [0.4, 0] });
+  });
+});

--- a/node/src/utils/correlationIndices.ts
+++ b/node/src/utils/correlationIndices.ts
@@ -1,0 +1,71 @@
+import { PlotData } from "plotly.js";
+import { OsparcFunctionJob } from "../context/types";
+import { fetchWithRetry } from "./fetchRetry";
+
+export type FetchCorrelationIndicesParams = {
+  inputVars: string[];
+  output: string | undefined;
+  distributions: InputVarSelection;
+  functionJobs: OsparcFunctionJob[];
+  numSamples: number;
+  seed?: number;
+};
+
+/**
+ * Fetch per-input <-> output Pearson/Spearman correlation coefficients from the
+ * backend (#470), computed on the same Monte Carlo sample set used for UQ propagation.
+ */
+export async function fetchCorrelationIndices(params: FetchCorrelationIndicesParams): Promise<CorrelationIndicesResponse> {
+  const { inputVars, output, distributions, functionJobs, numSamples, seed = 0 } = params;
+
+  const response = await fetchWithRetry(`/flask/dakota/compute_correlation_indices`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      inputVars,
+      output,
+      distributions,
+      numSamples,
+      FunctionJobs: functionJobs,
+      seed,
+    }),
+  });
+
+  if (!response.ok) {
+    // V23-style: reject (⊥ resolve) on non-OK so callers' .catch/try-catch can clear
+    // any cached fetch-dedup state instead of treating the failure as a success.
+    throw new Error(`Error in correlation indices response: ${response.status}, ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Build a grouped bar-chart trace (Pearson vs Spearman) showing the correlation
+ * strength of every input variable to the selected QoI in a single plot (#470).
+ */
+export function buildCorrelationBarData(
+  correlations: CorrelationIndicesResponse["correlations"],
+  inputVars: string[],
+  colors: { pearson: string; spearman: string },
+): Partial<PlotData>[] {
+  const pearsonValues = inputVars.map(inputVar => correlations[inputVar]?.pearson ?? 0);
+  const spearmanValues = inputVars.map(inputVar => correlations[inputVar]?.spearman ?? 0);
+
+  return [
+    {
+      x: inputVars,
+      y: pearsonValues,
+      type: "bar",
+      name: "Pearson",
+      marker: { color: colors.pearson },
+    },
+    {
+      x: inputVars,
+      y: spearmanValues,
+      type: "bar",
+      name: "Spearman",
+      marker: { color: colors.spearman },
+    },
+  ];
+}

--- a/node/src/utils/plotScale.test.ts
+++ b/node/src/utils/plotScale.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { correlationSymlogRange, logFloor, sobolLogRange, symlogTicks, symlogTransform, toLogSafe } from "./plotScale";
+
+describe("toLogSafe", () => {
+  it("returns log10 of the value when above the floor", () => {
+    expect(toLogSafe(1)).toBeCloseTo(0);
+    expect(toLogSafe(0.01)).toBeCloseTo(-2);
+  });
+
+  it("clamps values below the floor instead of returning -Infinity", () => {
+    expect(toLogSafe(0)).toBeCloseTo(Math.log10(logFloor));
+    expect(toLogSafe(-5)).toBeCloseTo(Math.log10(logFloor));
+  });
+});
+
+describe("symlogTransform", () => {
+  it("is continuous and zero at the origin", () => {
+    expect(symlogTransform(0)).toBe(0);
+  });
+
+  it("is antisymmetric", () => {
+    expect(symlogTransform(0.5)).toBeCloseTo(-symlogTransform(-0.5));
+  });
+
+  it("collapses all values inside the floor band to exactly 0 (⊥ linear ramp, T39)", () => {
+    expect(symlogTransform(logFloor * 0.999999)).toBe(0);
+    expect(symlogTransform(-logFloor * 0.999999)).toBe(0);
+    expect(symlogTransform(logFloor / 2)).toBe(0);
+    expect(symlogTransform(-logFloor / 2)).toBe(0);
+  });
+
+  it("jumps only a small fraction of a decade at the floor boundary (collapsed zero band, T40)", () => {
+    expect(symlogTransform(logFloor)).toBeCloseTo(0.3, 6);
+    expect(symlogTransform(-logFloor)).toBeCloseTo(-0.3, 6);
+    // the jump must stay far narrower than the width of a real decade (1 unit)
+    expect(Math.abs(symlogTransform(logFloor))).toBeLessThan(0.5);
+  });
+
+  it("maps 1 and -1 to the ends of the fixed correlation symlog range", () => {
+    expect(symlogTransform(1)).toBeCloseTo(correlationSymlogRange[1]);
+    expect(symlogTransform(-1)).toBeCloseTo(correlationSymlogRange[0]);
+  });
+
+  it("is monotonically non-decreasing (flat 0 inside the collapsed floor band)", () => {
+    const xs = [-1, -0.5, -0.01, -0.0001, 0, 0.0001, 0.01, 0.5, 1];
+    const ys = xs.map(symlogTransform);
+    for (let i = 1; i < ys.length; i += 1) {
+      expect(ys[i]).toBeGreaterThanOrEqual(ys[i - 1]);
+    }
+  });
+});
+
+describe("symlogTicks", () => {
+  it("returns matching tickvals/ticktext arrays covering -1..1", () => {
+    const { tickvals, ticktext } = symlogTicks();
+    expect(tickvals).toHaveLength(ticktext.length);
+    expect(ticktext).toContain("0");
+    expect(ticktext).toContain("1");
+    expect(ticktext).toContain("-1");
+  });
+});
+
+describe("sobolLogRange", () => {
+  it("spans 1e-2 to 1 in log10 units", () => {
+    expect(sobolLogRange).toEqual([-2, 0]);
+  });
+});

--- a/node/src/utils/plotScale.ts
+++ b/node/src/utils/plotScale.ts
@@ -1,0 +1,64 @@
+// Shared axis-scale helpers for the Sobol'/Correlation single-plot sensitivity views (#502).
+// Sobol' indices live in [0, 1] (mostly non-negative, small negative MC noise possible per
+// §V32) so a plain log scale works; correlation coefficients live in [-1, 1] and can be
+// negative, so they need a symlog-style transform. Both scales share the same floor so the
+// two plots stay visually comparable: values with |v| < LOG_FLOOR are indistinguishable from
+// zero and are clamped to the floor instead of blowing up the axis.
+
+export const logFloor = 1e-2;
+const logFloorExponent = Math.log10(logFloor); // -2
+
+/** log10(value), clamped to logFloor — for non-negative values (Sobol' indices). */
+export function toLogSafe(value: number): number {
+  return Math.log10(Math.max(value, logFloor));
+}
+
+/**
+ * Symlog transform for signed values (correlation coefficients): values inside
+ * the floor band `(-logFloor, logFloor)` collapse to exactly 0 (indistinguishable
+ * from noise at this precision, so no point spreading them out visually),
+ * log-scaled magnitude beyond it. Monotonic (non-decreasing) across zero, unlike
+ * a plain log scale which cannot represent negative values; NOT continuous at
+ * ±logFloor by design (a deliberate visual gap separating "zero" from "real
+ * effect", T39). The jump at the boundary is deliberately kept small
+ * (`zeroBandWidth`, far narrower than a full decade's width of 1) so the
+ * collapsed "zero" region doesn't visually eat up as much axis space as an
+ * actual decade of real data would (T40).
+ */
+const zeroBandWidth = 0.3;
+export function symlogTransform(value: number): number {
+  const magnitude = Math.abs(value);
+  if (magnitude < logFloor) {
+    return 0;
+  }
+  return Math.sign(value) * (zeroBandWidth + Math.log10(magnitude / logFloor));
+}
+
+/** Tick positions (in transformed symlog space) and labels (original values) spanning -1..1. */
+export function symlogTicks(): { tickvals: number[]; ticktext: string[] } {
+  // Decades from 1 down to logFloor (e.g. [1, 0.1, 0.01] for logFloor=1e-2) —
+  // derived from logFloorExponent so this stays in sync if the floor changes.
+  const numDecades = Math.round(-logFloorExponent);
+  const magnitudes = Array.from({ length: numDecades + 1 }, (_, i) => 10 ** -i);
+  const positive = magnitudes.map(m => ({ val: symlogTransform(m), text: String(m) }));
+  const negative = magnitudes.map(m => ({ val: symlogTransform(-m), text: String(-m) }));
+  const all = [...negative.reverse(), { val: 0, text: "0" }, ...positive];
+  return {
+    tickvals: all.map(t => t.val),
+    ticktext: all.map(t => t.text),
+  };
+}
+
+/** Fixed axis ranges so plots for different QoIs stay visually comparable. */
+export const sobolLinearRange: [number, number] = [0, 1];
+// Plotly log-axis `range` is expressed in log10 units, so [1e-3, 1] → [-3, 0].
+export const sobolLogRange: [number, number] = [logFloorExponent, 0];
+
+export const correlationLinearRange: [number, number] = [-1, 1];
+export const correlationSymlogRange: [number, number] = [symlogTransform(-1), symlogTransform(1)];
+// abs(correlation) on a native Plotly log axis — same floor/range as Sobol' indices, since
+// both are in [0, 1] once the sign is dropped.
+export const correlationAbsLogRange: [number, number] = [logFloorExponent, 0];
+
+export type ScaleType = "linear" | "log";
+export type CorrelationScaleType = "linear" | "symlog" | "abslog";

--- a/node/src/utils/sobolIndices.test.ts
+++ b/node/src/utils/sobolIndices.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OsparcFunctionJob } from "../context/types";
+import { fetchWithRetry } from "./fetchRetry";
+import { buildSobolBarData, buildSobolHeatmapData, fetchSobolIndices } from "./sobolIndices";
+
+vi.mock("./fetchRetry", () => ({
+  fetchWithRetry: vi.fn(),
+}));
+
+const mockedFetchWithRetry = vi.mocked(fetchWithRetry);
+
+const mockJobs: OsparcFunctionJob[] = [
+  { uid: "job1", functionUid: "func1", inputs: { x1: 1 }, outputs: { y: 2 }, status: "COMPLETED" },
+];
+
+beforeEach(() => {
+  mockedFetchWithRetry.mockReset();
+});
+
+describe("fetchSobolIndices", () => {
+  it("posts the expected payload and returns the parsed response on success", async () => {
+    const mockResponseBody: SobolIndicesResponse = {
+      sobol: {
+        x1: { main: 0.7, total: 0.9, mainCiLow: 0.7, mainCiHigh: 0.7, totalCiLow: 0.9, totalCiHigh: 0.9 },
+        x2: { main: 0.1, total: 0.2, mainCiLow: 0.1, mainCiHigh: 0.1, totalCiLow: 0.2, totalCiHigh: 0.2 },
+      },
+      sobolSecondOrder: {
+        x1: { x2: 0.05 },
+        x2: { x1: 0.05 },
+      },
+    };
+    mockedFetchWithRetry.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponseBody),
+    } as Response);
+
+    const result = await fetchSobolIndices({
+      inputVars: ["x1", "x2"],
+      output: "y",
+      distributions: { x1: { distribution: "uniform", min: 0, max: 1 } },
+      functionJobs: mockJobs,
+      numSamples: 500,
+      seed: 42,
+    });
+
+    expect(result).toEqual(mockResponseBody);
+    expect(mockedFetchWithRetry).toHaveBeenCalledWith(
+      "/flask/dakota/compute_sobol_indices",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const [, options] = mockedFetchWithRetry.mock.calls[0];
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body).toEqual({
+      inputVars: ["x1", "x2"],
+      output: "y",
+      distributions: { x1: { distribution: "uniform", min: 0, max: 1 } },
+      numSamples: 500,
+      FunctionJobs: mockJobs,
+      seed: 42,
+    });
+  });
+
+  it("defaults seed to 0 when not provided (backend scipy accepts seed >= 0)", async () => {
+    mockedFetchWithRetry.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ sobol: {}, sobolSecondOrder: {} }),
+    } as Response);
+
+    await fetchSobolIndices({
+      inputVars: ["x1"],
+      output: "y",
+      distributions: {},
+      functionJobs: mockJobs,
+      numSamples: 100,
+    });
+
+    const [, options] = mockedFetchWithRetry.mock.calls[0];
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body.seed).toBe(0);
+  });
+
+  it("throws (⊥ resolves) on a non-OK response", async () => {
+    mockedFetchWithRetry.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve({ sobol: {}, sobolSecondOrder: {} }),
+    } as Response);
+
+    await expect(
+      fetchSobolIndices({
+        inputVars: ["x1"],
+        output: "y",
+        distributions: {},
+        functionJobs: mockJobs,
+        numSamples: 100,
+      }),
+    ).rejects.toThrow(/500/);
+  });
+});
+
+describe("buildSobolBarData", () => {
+  it("builds one Main-effect trace and one Total-effect trace, ordered by inputVars", () => {
+    const sobol: SobolIndicesResponse["sobol"] = {
+      x1: { main: 0.7, total: 0.9, mainCiLow: 0.7, mainCiHigh: 0.7, totalCiLow: 0.9, totalCiHigh: 0.9 },
+      x2: { main: 0.1, total: 0.2, mainCiLow: 0.1, mainCiHigh: 0.1, totalCiLow: 0.2, totalCiHigh: 0.2 },
+    };
+
+    const traces = buildSobolBarData(sobol, ["x1", "x2"], {
+      main: "#111111",
+      total: "#222222",
+    });
+
+    expect(traces).toHaveLength(2);
+    expect(traces[0]).toMatchObject({ x: ["x1", "x2"], y: [0.7, 0.1], name: "Main effect", type: "bar" });
+    expect(traces[1]).toMatchObject({ x: ["x1", "x2"], y: [0.9, 0.2], name: "Total effect", type: "bar" });
+  });
+
+  it("falls back to 0 for input variables missing from the sobol map", () => {
+    const traces = buildSobolBarData(
+      { x1: { main: 0.5, total: 0.6, mainCiLow: 0.5, mainCiHigh: 0.5, totalCiLow: 0.6, totalCiHigh: 0.6 } },
+      ["x1", "x2"],
+      {
+        main: "#111111",
+        total: "#222222",
+      },
+    );
+
+    expect(traces[0]).toMatchObject({ y: [0.5, 0] });
+    expect(traces[1]).toMatchObject({ y: [0.6, 0] });
+  });
+});
+
+describe("buildSobolHeatmapData", () => {
+  const getZ = (trace: ReturnType<typeof buildSobolHeatmapData>): number[][] => trace.z as number[][];
+
+  it("returns a heatmap trace with correct shape", () => {
+    const sobol: SobolIndicesResponse["sobol"] = {
+      x1: { main: 0.7, total: 0.9, mainCiLow: 0.7, mainCiHigh: 0.7, totalCiLow: 0.9, totalCiHigh: 0.9 },
+      x2: { main: 0.1, total: 0.2, mainCiLow: 0.1, mainCiHigh: 0.1, totalCiLow: 0.2, totalCiHigh: 0.2 },
+    };
+    const sobolSecondOrder: SobolIndicesResponse["sobolSecondOrder"] = {
+      x1: { x2: 0.05 },
+      x2: { x1: 0.05 },
+    };
+
+    const trace = buildSobolHeatmapData(sobol, sobolSecondOrder, ["x1", "x2"]);
+
+    expect(trace.type).toBe("heatmap");
+    expect(trace.x).toEqual(["x1", "x2"]);
+    expect(trace.y).toEqual(["x1", "x2"]);
+    expect(trace.z).toHaveLength(2);
+    expect(getZ(trace)[0]).toHaveLength(2);
+    expect(getZ(trace)[1]).toHaveLength(2);
+  });
+
+  it("fills diagonal cells with first-order (main) index", () => {
+    const sobol: SobolIndicesResponse["sobol"] = {
+      x1: { main: 0.7, total: 0.9, mainCiLow: 0.7, mainCiHigh: 0.7, totalCiLow: 0.9, totalCiHigh: 0.9 },
+      x2: { main: 0.1, total: 0.2, mainCiLow: 0.1, mainCiHigh: 0.1, totalCiLow: 0.2, totalCiHigh: 0.2 },
+    };
+    const sobolSecondOrder: SobolIndicesResponse["sobolSecondOrder"] = {
+      x1: { x2: 0.05 },
+      x2: { x1: 0.05 },
+    };
+
+    const trace = buildSobolHeatmapData(sobol, sobolSecondOrder, ["x1", "x2"]);
+
+    expect(getZ(trace)[0][0]).toBe(0.7);
+    expect(getZ(trace)[1][1]).toBe(0.1);
+  });
+
+  it("places symmetric pairwise second-order values correctly", () => {
+    const sobol: SobolIndicesResponse["sobol"] = {
+      x1: { main: 0.5, total: 0.7, mainCiLow: 0.5, mainCiHigh: 0.5, totalCiLow: 0.7, totalCiHigh: 0.7 },
+      x2: { main: 0.3, total: 0.5, mainCiLow: 0.3, mainCiHigh: 0.3, totalCiLow: 0.5, totalCiHigh: 0.5 },
+      x3: { main: 0.1, total: 0.2, mainCiLow: 0.1, mainCiHigh: 0.1, totalCiLow: 0.2, totalCiHigh: 0.2 },
+    };
+    const sobolSecondOrder: SobolIndicesResponse["sobolSecondOrder"] = {
+      x1: { x2: 0.08, x3: 0.03 },
+      x2: { x1: 0.08, x3: 0.02 },
+      x3: { x1: 0.03, x2: 0.02 },
+    };
+
+    const trace = buildSobolHeatmapData(sobol, sobolSecondOrder, ["x1", "x2", "x3"]);
+
+    // off-diagonal: x1↔x2
+    expect(getZ(trace)[0][1]).toBe(0.08);
+    expect(getZ(trace)[1][0]).toBe(0.08);
+    // off-diagonal: x1↔x3
+    expect(getZ(trace)[0][2]).toBe(0.03);
+    expect(getZ(trace)[2][0]).toBe(0.03);
+    // off-diagonal: x2↔x3
+    expect(getZ(trace)[1][2]).toBe(0.02);
+    expect(getZ(trace)[2][1]).toBe(0.02);
+  });
+
+  it("handles missing second-order entries by falling back to 0", () => {
+    const sobol: SobolIndicesResponse["sobol"] = {
+      x1: { main: 0.4, total: 0.6, mainCiLow: 0.4, mainCiHigh: 0.4, totalCiLow: 0.6, totalCiHigh: 0.6 },
+      x2: { main: 0.2, total: 0.3, mainCiLow: 0.2, mainCiHigh: 0.2, totalCiLow: 0.3, totalCiHigh: 0.3 },
+    };
+    const sobolSecondOrder: SobolIndicesResponse["sobolSecondOrder"] = {};
+
+    const trace = buildSobolHeatmapData(sobol, sobolSecondOrder, ["x1", "x2"]);
+
+    // diagonal should still have first-order values
+    expect(getZ(trace)[0][0]).toBe(0.4);
+    expect(getZ(trace)[1][1]).toBe(0.2);
+    // off-diagonal should be 0
+    expect(getZ(trace)[0][1]).toBe(0);
+    expect(getZ(trace)[1][0]).toBe(0);
+  });
+
+  it("handles missing first-order entries by falling back to 0 on diagonal", () => {
+    const sobol: SobolIndicesResponse["sobol"] = {};
+    const sobolSecondOrder: SobolIndicesResponse["sobolSecondOrder"] = {};
+
+    const trace = buildSobolHeatmapData(sobol, sobolSecondOrder, ["x1", "x2"]);
+
+    expect(getZ(trace)[0][0]).toBe(0);
+    expect(getZ(trace)[1][1]).toBe(0);
+  });
+});

--- a/node/src/utils/sobolIndices.ts
+++ b/node/src/utils/sobolIndices.ts
@@ -1,0 +1,114 @@
+import { PlotData } from "plotly.js";
+import { OsparcFunctionJob } from "../context/types";
+import { fetchWithRetry } from "./fetchRetry";
+
+export type FetchSobolIndicesParams = {
+  inputVars: string[];
+  output: string | undefined;
+  distributions: InputVarSelection;
+  functionJobs: OsparcFunctionJob[];
+  numSamples: number;
+  seed?: number;
+};
+
+/**
+ * Fetch per-input first-order (main effect) and total-order Sobol' sensitivity
+ * indices plus pairwise second-order indices from the backend, computed via
+ * scipy on a surrogate model built from the completed jobs.
+ */
+export async function fetchSobolIndices(params: FetchSobolIndicesParams): Promise<SobolIndicesResponse> {
+  const { inputVars, output, distributions, functionJobs, numSamples, seed = 0 } = params;
+
+  const response = await fetchWithRetry(`/flask/dakota/compute_sobol_indices`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      inputVars,
+      output,
+      distributions,
+      numSamples,
+      FunctionJobs: functionJobs,
+      seed,
+    }),
+  });
+
+  if (!response.ok) {
+    // V23-style: reject (⊥ resolve) on non-OK so callers' .catch/try-catch can clear
+    // any cached fetch-dedup state instead of treating the failure as a success.
+    throw new Error(`Error in Sobol' indices response: ${response.status}, ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Build a grouped bar-chart trace (Main vs Total effect) showing the Sobol'
+ * sensitivity of every input variable to the selected QoI in a single plot.
+ */
+export function buildSobolBarData(
+  sobol: SobolIndicesResponse["sobol"],
+  inputVars: string[],
+  colors: { main: string; total: string },
+): Partial<PlotData>[] {
+  const mainValues = inputVars.map(inputVar => sobol[inputVar]?.main ?? 0);
+  const totalValues = inputVars.map(inputVar => sobol[inputVar]?.total ?? 0);
+
+  return [
+    {
+      x: inputVars,
+      y: mainValues,
+      type: "bar",
+      name: "Main effect",
+      marker: { color: colors.main },
+    },
+    {
+      x: inputVars,
+      y: totalValues,
+      type: "bar",
+      name: "Total effect",
+      marker: { color: colors.total },
+    },
+  ];
+}
+
+/**
+ * Build a Plotly heatmap trace for second-order Sobol' indices.
+ * Diagonal cells are filled from the corresponding first-order (main) index.
+ * Off-diagonal cells come from the symmetric sobolSecondOrder pairwise matrix.
+ */
+export function buildSobolHeatmapData(
+  sobol: SobolIndicesResponse["sobol"],
+  sobolSecondOrder: SobolIndicesResponse["sobolSecondOrder"],
+  inputVars: string[],
+  colorScale?: string,
+): Partial<PlotData> {
+  const n = inputVars.length;
+  const z: number[][] = [];
+
+  for (let i = 0; i < n; i += 1) {
+    const row: number[] = [];
+    for (let j = 0; j < n; j += 1) {
+      if (i === j) {
+        row.push(sobol[inputVars[i]]?.main ?? 0);
+      } else {
+        const varA = inputVars[i];
+        const varB = inputVars[j];
+        const vA = sobolSecondOrder[varA]?.[varB];
+        const vB = sobolSecondOrder[varB]?.[varA];
+        row.push(vA ?? vB ?? 0);
+      }
+    }
+    z.push(row);
+  }
+
+  return {
+    z,
+    x: inputVars,
+    y: inputVars,
+    type: "heatmap",
+    colorscale: colorScale || "Viridis",
+    colorbar: { title: { text: "Sobol' index" } },
+    hoverongaps: false,
+    hovertemplate: "%{x} ↔ %{y}: %{z:.4f}<extra></extra>",
+  };
+}

--- a/node/src/views/UQ.tsx
+++ b/node/src/views/UQ.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useMMUXContext } from "../context/MMUXContext";
-import UncertainUQ from "../components/plots/UncertainUQ";
+import UQPlotsSteps from "../components/plots/UQPlotsSteps";
 import SuMoModal from "./SuMoModal";
 import MetaModelingUX from "../components/navigation/MetaModelingUX";
 import { OutputSetup } from "./OutputSetup";
@@ -25,7 +25,7 @@ export default function UQ() {
   return (
     <MetaModelingUX headerType="title" tabTitle={`Uncertainty Quantification: ${selectedFunction?.title}`}>
       <OutputSetup loading={loading} setSumoModal={setSumoModal} mode="full" />
-      <UncertainUQ colsFetched={colsFetched} jobProgress={jobProgress} jobsFetched={jobsFetched} loading={loading} />
+      <UQPlotsSteps loading={loading} jobProgress={jobProgress} colsFetched={colsFetched} jobsFetched={jobsFetched} />
       <SuMoModal open={sumoModal} setOpen={setSumoModal} />
       <JobSampling
         loading={loading}


### PR DESCRIPTION
Adds correlation and Sobol sensitivity utilities and plots, plot-scale helpers, and the stepped UQ/SuMo results flow.

Validation:
- 46 focused Vitest tests pass
- npm run build passes
- npm run lint passes with pre-existing warnings