### PR TITLE
fix(node): surface backend errors in UQ plots

### DIFF
--- a/node/src/components/plots/CorrelationIndicesPlot.tsx
+++ b/node/src/components/plots/CorrelationIndicesPlot.tsx
@@ -76,12 +76,14 @@ export default function CorrelationIndicesPlot({ viewMode, scaleType }: Correlat
   const { fetchedJobCollections, filteredJobList } = useJobContext();
   const [correlations, setCorrelations] = useState<CorrelationIndicesResponse["correlations"] | null>(null);
   const [plotData, setPlotData] = useState<Plotly.Data[]>([]);
+  const [errorMessage, setErrorMessage] = useState<string>();
   const [computing, setComputing] = useState(false);
 
   useEffect(() => {
     (async () => {
       setCorrelations(null);
       setPlotData([]);
+      setErrorMessage(undefined);
       setComputing(true);
       if (filteredJobList.length === 0 || !selectedQoI) {
         console.warn("No jobs selected for correlation indices computation.");
@@ -98,11 +100,13 @@ export default function CorrelationIndicesPlot({ viewMode, scaleType }: Correlat
           seed: 0,
         });
         setCorrelations(data.correlations);
+        setErrorMessage(undefined);
         setComputing(false);
       } catch (error) {
         console.warn("Error computing correlation indices:", error);
         setComputing(false);
         setCorrelations(null);
+        setErrorMessage(error instanceof Error ? error.message : String(error));
       }
     })();
   }, [filteredJobList, selectedQoI, numSamples, inputVars, distribution, selectedFunction]);
@@ -223,6 +227,7 @@ export default function CorrelationIndicesPlot({ viewMode, scaleType }: Correlat
           fetchedJobCollections={fetchedJobCollections}
           filteredJobList={filteredJobList}
           height={plotStyle.height}
+          errorMessage={errorMessage}
           numInputVars={inputVars.length}
         />
       )}

--- a/node/src/components/plots/Curves1DPlot.tsx
+++ b/node/src/components/plots/Curves1DPlot.tsx
@@ -10,6 +10,7 @@ import InsufficientDataWarning from "./InsufficientDataWarning";
 import { useFunctionContext } from "../../context/FunctionContext";
 import { useJobContext } from "../../context/JobContext";
 import { buildDakotaRequestKey } from "../../utils/dakotaRequestKey";
+import { getResponseErrorMessage } from "../../utils/httpError";
 
 type GPPrediction = {
   x: number[];
@@ -32,6 +33,7 @@ function Curves1DPlots() {
   const [plotData, setPlotData] = useState<Array<Data>>([]);
   const [axis, setAxis] = useState(filteredInputVars[0]);
   const [propagating, setPropagating] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
   const [otherAxis, setOtherAxis] = useState<{ [key: string]: number }>(
     inputVars.reduce((acc: { [key: string]: number }, key) => {
       acc[key] =
@@ -100,6 +102,7 @@ function Curves1DPlots() {
 
   const RunCentralSuMoInterpolations = async (jobs: OsparcFunctionJob[], requestKey: string) => {
     setPropagating(true);
+    setErrorMessage(undefined);
     // NB do NOT set plotData to [] to allow "interactive" slider movement wo the "Calculating" word flashing
     fetch(`/flask/dakota/sumo_along_axes`, {
       method: "POST",
@@ -113,12 +116,12 @@ function Curves1DPlots() {
         log: false,
       }),
     })
-      .then(response => {
+      .then(async response => {
         if (response && !response.ok) {
           console.warn("SuMo Curves plot error: ", response.body);
           // V18: reject (⊥ return/resolve) so the .catch path clears lastFetchedKey and
           // the identical inputs can be retried instead of caching a failed fetch.
-          return Promise.reject(new Error(`SuMo Curves plot response not ok: ${response.status}, ${response.statusText}`));
+          return Promise.reject(new Error(await getResponseErrorMessage(response)));
         }
         return response.json();
       })
@@ -128,12 +131,14 @@ function Curves1DPlots() {
         // V18: cache key ONLY on success, so transient failures don't block retry
         lastFetchedKey.current = requestKey;
         setPropagating(false);
+        setErrorMessage(undefined);
       })
-      .catch(_error => {
+      .catch(error => {
         // V18: clear cache on error so same inputs can be retried
         lastFetchedKey.current = undefined;
         setPlotData([]);
         setPropagating(false);
+        setErrorMessage(error instanceof Error ? error.message : String(error));
       });
   };
 
@@ -199,6 +204,7 @@ function Curves1DPlots() {
             fetchedJobCollections={fetchedJobCollections}
             filteredJobList={filteredJobList}
             height={plotStyle.height}
+            errorMessage={errorMessage}
             numInputVars={inputVars.length}
           />
         )}

--- a/node/src/components/plots/InsufficientDataWarning.test.tsx
+++ b/node/src/components/plots/InsufficientDataWarning.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { describe, expect, it } from "vitest";
+import InsufficientDataWarning from "./InsufficientDataWarning";
+
+describe("InsufficientDataWarning", () => {
+  it("shows an explicit request error instead of the generic support message", () => {
+    render(
+      <InsufficientDataWarning
+        fetchedJobCollections={undefined}
+        filteredJobList={[]}
+        numInputVars={3}
+        errorMessage="Input variables are missing from completed job inputs: internal_gap_max_mm"
+      />,
+    );
+
+    expect(screen.getByText(/Input variables are missing/)).toBeInTheDocument();
+    expect(screen.queryByText("Error during calculation, please contact support.")).toBeNull();
+  });
+});

--- a/node/src/components/plots/InsufficientDataWarning.tsx
+++ b/node/src/components/plots/InsufficientDataWarning.tsx
@@ -5,6 +5,7 @@ type InsufficientDataWarningPropsType = {
   fetchedJobCollections: SelectedJobCollection[] | undefined;
   filteredJobList: OsparcFunctionJob[];
   height?: number;
+  errorMessage?: string;
   // Number of input variables for the current function/model. Used to compute the
   // minimum completed jobs Dakota needs to build a surrogate: max(5, numInputVars + 1)
   // -- see flaskapi SPEC.md V30 -- and to pick the right explanation for why more
@@ -14,20 +15,23 @@ type InsufficientDataWarningPropsType = {
 
 // insert if plotData has length 0
 function InsufficientDataWarning(props: InsufficientDataWarningPropsType) {
-  const { fetchedJobCollections, filteredJobList, height, numInputVars } = props;
+  const { fetchedJobCollections, filteredJobList, height, numInputVars, errorMessage } = props;
   const minimumRequired = Math.max(5, numInputVars + 1);
   const isDimensionLimited = numInputVars + 1 > 5;
   const insufficientSamplesMessage = isDimensionLimited
     ? `You need at least ${minimumRequired} samples (one more than your ${numInputVars} input variables) to avoid an underdetermined system.`
     : `You need at least ${minimumRequired} samples.`;
   const hasEnoughSamples =
-    filteredJobList.length < minimumRequired ? insufficientSamplesMessage : "Error during calculation, please contact support.";
+    filteredJobList.length < minimumRequired
+      ? insufficientSamplesMessage
+      : errorMessage || "Error during calculation, please contact support.";
   return (
     <DisplayMessage
       mssg={
-        !fetchedJobCollections || fetchedJobCollections.length === 0
+        errorMessage ||
+        (!fetchedJobCollections || fetchedJobCollections.length === 0
           ? "No data available. Please create more Samples."
-          : hasEnoughSamples
+          : hasEnoughSamples)
       }
       height={height}
     />

--- a/node/src/components/plots/IsoSurface3DPlot.tsx
+++ b/node/src/components/plots/IsoSurface3DPlot.tsx
@@ -10,6 +10,7 @@ import InsufficientDataWarning from "./InsufficientDataWarning";
 import { useFunctionContext } from "../../context/FunctionContext";
 import { useJobContext } from "../../context/JobContext";
 import { buildDakotaRequestKey } from "../../utils/dakotaRequestKey";
+import { getResponseErrorMessage } from "../../utils/httpError";
 
 function IsoSurface3DPlot() {
   const theme = useTheme();
@@ -28,6 +29,7 @@ function IsoSurface3DPlot() {
   const [axis2, setAxis2] = useState(filteredInputVars[1]);
   const [axis3, setAxis3] = useState(filteredInputVars[2]);
   const [plotData, setPlotData] = useState<Array<Plotly.Data>>([]);
+  const [errorMessage, setErrorMessage] = useState<string>();
   const lastFetchedKey = useRef<string | undefined>(undefined);
   const [otherAxis, setOtherAxis] = useState<{ [key: string]: number }>(
     inputVars.reduce((acc: { [key: string]: number }, key) => {
@@ -158,6 +160,7 @@ function IsoSurface3DPlot() {
     console.info("Evaluating SuMo for 2D surface...");
     console.info("Jobs to build SuMo: ", jobs);
     setPropagating(true);
+    setErrorMessage(undefined);
     fetch(`/flask/dakota/sumo_grid_evaluation`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -170,10 +173,10 @@ function IsoSurface3DPlot() {
         log: false,
       }),
     })
-      .then(response => {
+      .then(async response => {
         if (response && !response.ok) {
           console.warn("SuMo Surface plot error: ", response.body);
-          return Promise.reject(new Error(`Error running SuMo Surface plot: ${response.status}, ${response.statusText}`));
+          return Promise.reject(new Error(await getResponseErrorMessage(response)));
         }
         return response.json();
       })
@@ -183,6 +186,7 @@ function IsoSurface3DPlot() {
         // V18: cache key ONLY on success, so transient failures don't block retry
         lastFetchedKey.current = requestKey;
         setPropagating(false);
+        setErrorMessage(undefined);
       })
       .catch(error => {
         // V18: clear cache on error so same inputs can be retried
@@ -190,6 +194,7 @@ function IsoSurface3DPlot() {
         console.warn("Error:", error);
         setPropagating(false);
         setPlotData([]);
+        setErrorMessage(error instanceof Error ? error.message : String(error));
       });
   };
 
@@ -252,6 +257,7 @@ function IsoSurface3DPlot() {
           fetchedJobCollections={fetchedJobCollections}
           filteredJobList={filteredJobList}
           height={plotStyle.height}
+          errorMessage={errorMessage}
           numInputVars={inputVars.length}
         />
       )}

--- a/node/src/components/plots/SobolIndicesPlot.tsx
+++ b/node/src/components/plots/SobolIndicesPlot.tsx
@@ -63,12 +63,14 @@ export default function SobolIndicesPlot({ viewMode, scaleType }: SobolIndicesPl
   const { fetchedJobCollections, filteredJobList } = useJobContext();
   const [sobolData, setSobolData] = useState<SobolIndicesResponse | null>(null);
   const [plotData, setPlotData] = useState<Plotly.Data[]>([]);
+  const [errorMessage, setErrorMessage] = useState<string>();
   const [computing, setComputing] = useState(false);
 
   useEffect(() => {
     (async () => {
       setSobolData(null);
       setPlotData([]);
+      setErrorMessage(undefined);
       setComputing(true);
       if (filteredJobList.length === 0 || !selectedQoI) {
         console.warn("No jobs selected for Sobol' indices computation.");
@@ -85,11 +87,13 @@ export default function SobolIndicesPlot({ viewMode, scaleType }: SobolIndicesPl
           seed: 0,
         });
         setSobolData(data);
+        setErrorMessage(undefined);
         setComputing(false);
       } catch (error) {
         console.warn("Error computing Sobol' indices:", error);
         setComputing(false);
         setSobolData(null);
+        setErrorMessage(error instanceof Error ? error.message : String(error));
       }
     })();
   }, [filteredJobList, selectedQoI, numSamples, inputVars, distribution, selectedFunction]);
@@ -216,6 +220,7 @@ export default function SobolIndicesPlot({ viewMode, scaleType }: SobolIndicesPl
           fetchedJobCollections={fetchedJobCollections}
           filteredJobList={filteredJobList}
           height={plotStyle.height}
+          errorMessage={errorMessage}
           numInputVars={inputVars.length}
         />
       )}

--- a/node/src/components/plots/SuMoValidation.tsx
+++ b/node/src/components/plots/SuMoValidation.tsx
@@ -11,6 +11,7 @@ import CalculatingWarning from "./CalculatingWarning";
 import InsufficientDataWarning from "./InsufficientDataWarning";
 import { useFunctionContext } from "../../context/FunctionContext";
 import { useJobContext } from "../../context/JobContext";
+import { getResponseErrorMessage } from "../../utils/httpError";
 
 function SuMoValidation() {
   const theme = useTheme();
@@ -20,6 +21,7 @@ function SuMoValidation() {
   const [cvMetrics, setCvMetrics] = useState<CvMetricsType>();
   const [plotData, setPlotData] = useState<Partial<Plotly.ViolinData>[]>([]);
   const [propagating, setPropagating] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
   const [width, setWidth] = useState(1080);
   const boxRef = useRef<HTMLDivElement>(null);
 
@@ -97,6 +99,7 @@ function SuMoValidation() {
     setCvMetrics(undefined);
     setPlotData([]);
     setPropagating(true);
+    setErrorMessage(undefined);
 
     fetch(`/flask/dakota/sumo_cross_validation`, {
       method: "POST",
@@ -108,7 +111,12 @@ function SuMoValidation() {
         log: false,
       }),
     })
-      .then(response => response.json())
+      .then(async response => {
+        if (response && !response.ok) {
+          return Promise.reject(new Error(await getResponseErrorMessage(response)));
+        }
+        return response.json();
+      })
       .then(response => {
         if (!response || (response && response.error)) {
           console.warn("SuMo Validation error: ", response.error);
@@ -117,6 +125,7 @@ function SuMoValidation() {
           const data = response;
           createDataAndMetrics(data);
           setPropagating(false);
+          setErrorMessage(undefined);
         }
       })
       .catch(error => {
@@ -124,6 +133,7 @@ function SuMoValidation() {
         setPropagating(false);
         setPlotData([]);
         setCvMetrics(undefined);
+        setErrorMessage(error instanceof Error ? error.message : String(error));
       });
   };
 
@@ -133,6 +143,69 @@ function SuMoValidation() {
       return RunSuMoValidation(jobs);
     };
     run();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedQoI, inputVars, selectedFunction, distribution, filteredJobList]);
+
+  // V25 (../flaskapi/SPEC.md V26/V27): paired t-test bias banner + convergence curve,
+  // fetched from the (now populated) `/get_sumo_cv_accuracy_metrics` endpoint alongside
+  // the existing MAE/RMSE + CV scatter above.
+  const RunCvAccuracyMetrics = async (jobs: OsparcFunctionJob[], requestKey: string) => {
+    fetch(`/flask/dakota/get_sumo_cv_accuracy_metrics`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        inputs: inputVars,
+        output: selectedQoI,
+        FunctionJobs: jobs,
+      }),
+    })
+      .then(async response => {
+        if (response && !response.ok) {
+          // V18/V23-style: reject (⊥ resolve) so .catch clears lastFetchedCvAccuracyKey
+          // and identical inputs can be retried instead of caching a failed fetch.
+          return Promise.reject(new Error(await getResponseErrorMessage(response)));
+        }
+        return response.json();
+      })
+      .then((data: SumoCvAccuracyMetricsResponse) => {
+        if (!data || data.error) {
+          return Promise.reject(new Error(`Error fetching SuMo CV accuracy metrics: ${data?.error}`));
+        }
+        setTTest(data.tTest);
+        setConvergence(data.convergence || []);
+        lastFetchedCvAccuracyKey.current = requestKey;
+        return undefined;
+      })
+      .catch(error => {
+        console.warn("Error fetching SuMo CV accuracy metrics:", error);
+        lastFetchedCvAccuracyKey.current = undefined;
+        setTTest(undefined);
+        setConvergence([]);
+        setErrorMessage(error instanceof Error ? error.message : String(error));
+      });
+  };
+
+  useEffect(() => {
+    const jobs = filteredJobList;
+    if (!jobs || jobs.length < 5 || !selectedQoI) {
+      lastFetchedCvAccuracyKey.current = undefined;
+      setTTest(undefined);
+      setConvergence([]);
+      return;
+    }
+    // V16-style: dedup by stable logical request key; same key → no new fetch.
+    const requestKey = buildDakotaRequestKey({
+      axes: inputVars,
+      sliderValues: {},
+      qoi: selectedQoI,
+      fn: selectedFunction?.uid,
+      jobList: jobs.map(job => job.uid),
+      logScale: false,
+    });
+    if (requestKey === lastFetchedCvAccuracyKey.current) {
+      return;
+    }
+    RunCvAccuracyMetrics(jobs, requestKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedQoI, inputVars, selectedFunction, distribution, filteredJobList]);
 
@@ -190,6 +263,7 @@ function SuMoValidation() {
           fetchedJobCollections={fetchedJobCollections}
           filteredJobList={filteredJobList}
           height={plotStyle.height}
+          errorMessage={errorMessage}
           numInputVars={inputVars.length}
         />
       )}

--- a/node/src/components/plots/SuMoValidation.tsx
+++ b/node/src/components/plots/SuMoValidation.tsx
@@ -146,69 +146,6 @@ function SuMoValidation() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedQoI, inputVars, selectedFunction, distribution, filteredJobList]);
 
-  // V25 (../flaskapi/SPEC.md V26/V27): paired t-test bias banner + convergence curve,
-  // fetched from the (now populated) `/get_sumo_cv_accuracy_metrics` endpoint alongside
-  // the existing MAE/RMSE + CV scatter above.
-  const RunCvAccuracyMetrics = async (jobs: OsparcFunctionJob[], requestKey: string) => {
-    fetch(`/flask/dakota/get_sumo_cv_accuracy_metrics`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        inputs: inputVars,
-        output: selectedQoI,
-        FunctionJobs: jobs,
-      }),
-    })
-      .then(async response => {
-        if (response && !response.ok) {
-          // V18/V23-style: reject (⊥ resolve) so .catch clears lastFetchedCvAccuracyKey
-          // and identical inputs can be retried instead of caching a failed fetch.
-          return Promise.reject(new Error(await getResponseErrorMessage(response)));
-        }
-        return response.json();
-      })
-      .then((data: SumoCvAccuracyMetricsResponse) => {
-        if (!data || data.error) {
-          return Promise.reject(new Error(`Error fetching SuMo CV accuracy metrics: ${data?.error}`));
-        }
-        setTTest(data.tTest);
-        setConvergence(data.convergence || []);
-        lastFetchedCvAccuracyKey.current = requestKey;
-        return undefined;
-      })
-      .catch(error => {
-        console.warn("Error fetching SuMo CV accuracy metrics:", error);
-        lastFetchedCvAccuracyKey.current = undefined;
-        setTTest(undefined);
-        setConvergence([]);
-        setErrorMessage(error instanceof Error ? error.message : String(error));
-      });
-  };
-
-  useEffect(() => {
-    const jobs = filteredJobList;
-    if (!jobs || jobs.length < 5 || !selectedQoI) {
-      lastFetchedCvAccuracyKey.current = undefined;
-      setTTest(undefined);
-      setConvergence([]);
-      return;
-    }
-    // V16-style: dedup by stable logical request key; same key → no new fetch.
-    const requestKey = buildDakotaRequestKey({
-      axes: inputVars,
-      sliderValues: {},
-      qoi: selectedQoI,
-      fn: selectedFunction?.uid,
-      jobList: jobs.map(job => job.uid),
-      logScale: false,
-    });
-    if (requestKey === lastFetchedCvAccuracyKey.current) {
-      return;
-    }
-    RunCvAccuracyMetrics(jobs, requestKey);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedQoI, inputVars, selectedFunction, distribution, filteredJobList]);
-
   useEffect(() => {
     const resizeObserver = new ResizeObserver(event => {
       // Depending on the layout, you may need to swap inlineSize with blockSize

--- a/node/src/components/plots/Surface2DPlot.tsx
+++ b/node/src/components/plots/Surface2DPlot.tsx
@@ -10,6 +10,7 @@ import InsufficientDataWarning from "./InsufficientDataWarning";
 import { useFunctionContext } from "../../context/FunctionContext";
 import { useJobContext } from "../../context/JobContext";
 import { buildDakotaRequestKey } from "../../utils/dakotaRequestKey";
+import { getResponseErrorMessage } from "../../utils/httpError";
 
 function Surface2DPlot() {
   const theme = useTheme();
@@ -22,6 +23,7 @@ function Surface2DPlot() {
   const [axis2, setAxis2] = useState(filteredInputVars[1]);
   const [propagating, setPropagating] = useState(false);
   const [plotData, setPlotData] = useState<Array<Plotly.Data>>([]);
+  const [errorMessage, setErrorMessage] = useState<string>();
   const lastFetchedKey = useRef<string | undefined>(undefined);
   const [otherAxis, setOtherAxis] = useState<{ [key: string]: number }>(
     inputVars.reduce((acc: { [key: string]: number }, key) => {
@@ -84,6 +86,7 @@ function Surface2DPlot() {
       console.info("Evaluating SuMo for 2D surface...");
       console.info("Jobs to build SuMo: ", jobs);
       setPropagating(true);
+      setErrorMessage(undefined);
       fetch(`/flask/dakota/sumo_grid_evaluation`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -96,13 +99,13 @@ function Surface2DPlot() {
           log: false, // FIXME not used atm
         }),
       })
-        .then(response => {
+        .then(async response => {
           if (response && !response.ok) {
             console.warn("SuMo Surface plot error: ", response.body);
             // V18: reject (⊥ return) so the .catch path clears lastFetchedKey and the
             // identical inputs can be retried; a returned Error would resolve the chain
             // and cache the key as if the fetch had succeeded.
-            return Promise.reject(new Error(`SuMo Surface plot response not ok: ${response.status}, ${response.statusText}`));
+            return Promise.reject(new Error(await getResponseErrorMessage(response)));
           }
           return response.json();
         })
@@ -112,6 +115,7 @@ function Surface2DPlot() {
           // V18: cache key ONLY on success, so transient failures don't block retry
           lastFetchedKey.current = requestKey;
           setPropagating(false);
+          setErrorMessage(undefined);
         })
         .catch(error => {
           // V18: clear cache on error so same inputs can be retried
@@ -119,6 +123,7 @@ function Surface2DPlot() {
           console.warn("Error:", error);
           setPropagating(false);
           setPlotData([]);
+          setErrorMessage(error instanceof Error ? error.message : String(error));
         });
     },
     [inputVars, selectedQoI, otherAxis, reshapePlotData],
@@ -182,6 +187,7 @@ function Surface2DPlot() {
             fetchedJobCollections={fetchedJobCollections}
             filteredJobList={filteredJobList}
             height={plotStyle.height}
+            errorMessage={errorMessage}
             numInputVars={inputVars.length}
           />
         )}

--- a/node/src/components/plots/UncertainUQ.tsx
+++ b/node/src/components/plots/UncertainUQ.tsx
@@ -19,12 +19,14 @@ export default function UncertainUQ(props: LoadingPropsType) {
   const [dataUQHistogram, setDataUQHistogram] = useState<DataUQHistogramType>();
   const [plotData, setPlotData] = useState<Plotly.Data[]>([]);
   const [propagating, setPropagating] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
 
   useEffect(() => {
     (async () => {
       console.log("running job collections: ", filteredJobList);
       setDataUQHistogram(undefined);
       setPlotData([]);
+      setErrorMessage(undefined);
       setPropagating(true);
       if (filteredJobList.length === 0) {
         console.warn("No jobs selected for UQ propagation.");
@@ -49,7 +51,9 @@ export default function UncertainUQ(props: LoadingPropsType) {
           }),
         });
         if (!response.ok) {
-          throw new Error(`Error in UQ response: ${response.status}, ${response.statusText}`);
+          const errorPayload = await response.json().catch(() => undefined);
+          const serverMessage = errorPayload && typeof errorPayload.error === "string" ? errorPayload.error : undefined;
+          throw new Error(serverMessage || `Error in UQ response: ${response.status}, ${response.statusText}`);
         }
         const data: DataUQHistogramType = await response.json();
         const newPlotData: Plotly.Data[] = [
@@ -74,6 +78,7 @@ export default function UncertainUQ(props: LoadingPropsType) {
         setPropagating(false);
       } catch (error) {
         console.warn("Error:", error);
+        setErrorMessage(error instanceof Error ? error.message : "Error during calculation, please contact support.");
         setPropagating(false);
         setDataUQHistogram(undefined);
       }
@@ -107,6 +112,7 @@ export default function UncertainUQ(props: LoadingPropsType) {
           filteredJobList={filteredJobList}
           height={plotStyle.height}
           numInputVars={inputVars.length}
+          errorMessage={errorMessage}
         />
       )}
       {!propagating && plotData.length !== 0 && <Plot data={plotData} layout={layout} style={plotStyle} />}

--- a/node/src/utils/correlationIndices.test.ts
+++ b/node/src/utils/correlationIndices.test.ts
@@ -83,7 +83,12 @@ describe("fetchCorrelationIndices", () => {
       ok: false,
       status: 500,
       statusText: "Internal Server Error",
-      json: () => Promise.resolve({}),
+      json: () => Promise.resolve({ error: "Correlation model failed" }),
+      clone: () =>
+        ({
+          json: () => Promise.resolve({ error: "Correlation model failed" }),
+          text: () => Promise.resolve(""),
+        }) as Response,
     } as Response);
 
     await expect(
@@ -94,7 +99,7 @@ describe("fetchCorrelationIndices", () => {
         functionJobs: mockJobs,
         numSamples: 100,
       }),
-    ).rejects.toThrow(/500/);
+    ).rejects.toThrow("Correlation model failed");
   });
 });
 

--- a/node/src/utils/correlationIndices.ts
+++ b/node/src/utils/correlationIndices.ts
@@ -1,6 +1,7 @@
 import { PlotData } from "plotly.js";
 import { OsparcFunctionJob } from "../context/types";
 import { fetchWithRetry } from "./fetchRetry";
+import { getResponseErrorMessage } from "./httpError";
 
 export type FetchCorrelationIndicesParams = {
   inputVars: string[];
@@ -34,7 +35,7 @@ export async function fetchCorrelationIndices(params: FetchCorrelationIndicesPar
   if (!response.ok) {
     // V23-style: reject (⊥ resolve) on non-OK so callers' .catch/try-catch can clear
     // any cached fetch-dedup state instead of treating the failure as a success.
-    throw new Error(`Error in correlation indices response: ${response.status}, ${response.statusText}`);
+    throw new Error(await getResponseErrorMessage(response));
   }
 
   return response.json();

--- a/node/src/utils/fetchRetry.ts
+++ b/node/src/utils/fetchRetry.ts
@@ -15,18 +15,18 @@ export const fetchWithRetry = async (
     try {
       response = await fetch(url, options);
     } catch (error: unknown) {
-      if (attempt >= retries) {
-        ErrorToRetry = error as Error; // Re-throw the error after all retries have failed
-      }
+      ErrorToRetry = error as Error; // Capture the error so it can be re-thrown below
     }
     if ((response && response.ok) || (response && response.status === 404)) {
       return response; // If the response is successful or not found, return it immediately
     }
 
-    // Exponential backoff with jitter
-    const exponentialWait = Math.min(baseWait * 2 ** attempt, maxWait);
-    const jitter = Math.random() * (exponentialWait * 0.2);
-    await delay(exponentialWait + jitter);
+    // Exponential backoff with jitter; skip after the final attempt.
+    if (attempt < retries - 1) {
+      const exponentialWait = Math.min(baseWait * 2 ** attempt, maxWait);
+      const jitter = Math.random() * (exponentialWait * 0.2);
+      await delay(exponentialWait + jitter);
+    }
   }
 
   if (response) {

--- a/node/src/utils/fetchRetry.ts
+++ b/node/src/utils/fetchRetry.ts
@@ -29,6 +29,10 @@ export const fetchWithRetry = async (
     await delay(exponentialWait + jitter);
   }
 
+  if (response) {
+    return response;
+  }
+
   // If we reach here, it means all retries failed
   throw ErrorToRetry ?? new Error("fetchWithRetry: All retries failed and no error was captured."); // Re-throw the last error encountered
 };

--- a/node/src/utils/httpError.test.ts
+++ b/node/src/utils/httpError.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getResponseErrorMessage } from "./httpError";
+
+describe("getResponseErrorMessage", () => {
+  it("uses the backend error field when present", async () => {
+    const response = new Response(JSON.stringify({ error: "Input variables are missing" }), {
+      status: 400,
+      statusText: "Bad Request",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    await expect(getResponseErrorMessage(response)).resolves.toBe("Input variables are missing");
+  });
+
+  it("uses a text response when no JSON error field exists", async () => {
+    const response = new Response("Dakota failed to build the surrogate", {
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    await expect(getResponseErrorMessage(response)).resolves.toBe("Dakota failed to build the surrogate");
+  });
+
+  it("falls back to the HTTP status when the response body is empty", async () => {
+    const response = new Response(null, { status: 502, statusText: "Bad Gateway" });
+
+    await expect(getResponseErrorMessage(response)).resolves.toBe("Request failed: 502 Bad Gateway");
+  });
+});

--- a/node/src/utils/httpError.ts
+++ b/node/src/utils/httpError.ts
@@ -1,7 +1,6 @@
 export async function getResponseErrorMessage(response: Response): Promise<string> {
-  const responseCopy = response.clone();
   try {
-    const payload: unknown = await responseCopy.json();
+    const payload: unknown = await response.clone().json();
     if (payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string") {
       const message = payload.error.trim();
       if (message) return message;

--- a/node/src/utils/httpError.ts
+++ b/node/src/utils/httpError.ts
@@ -1,0 +1,21 @@
+export async function getResponseErrorMessage(response: Response): Promise<string> {
+  const responseCopy = response.clone();
+  try {
+    const payload: unknown = await responseCopy.json();
+    if (payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string") {
+      const message = payload.error.trim();
+      if (message) return message;
+    }
+  } catch {
+    // Fall back to a plain-text body below.
+  }
+
+  try {
+    const text = (await response.clone().text()).trim();
+    if (text) return text;
+  } catch {
+    // Use the HTTP status when the body cannot be read.
+  }
+
+  return `Request failed: ${response.status} ${response.statusText}`.trim();
+}

--- a/node/src/utils/sobolIndices.test.ts
+++ b/node/src/utils/sobolIndices.test.ts
@@ -87,7 +87,12 @@ describe("fetchSobolIndices", () => {
       ok: false,
       status: 500,
       statusText: "Internal Server Error",
-      json: () => Promise.resolve({ sobol: {}, sobolSecondOrder: {} }),
+      json: () => Promise.resolve({ error: "Sobol model failed" }),
+      clone: () =>
+        ({
+          json: () => Promise.resolve({ error: "Sobol model failed" }),
+          text: () => Promise.resolve(""),
+        }) as Response,
     } as Response);
 
     await expect(
@@ -98,7 +103,7 @@ describe("fetchSobolIndices", () => {
         functionJobs: mockJobs,
         numSamples: 100,
       }),
-    ).rejects.toThrow(/500/);
+    ).rejects.toThrow("Sobol model failed");
   });
 });
 

--- a/node/src/utils/sobolIndices.ts
+++ b/node/src/utils/sobolIndices.ts
@@ -1,6 +1,7 @@
 import { PlotData } from "plotly.js";
 import { OsparcFunctionJob } from "../context/types";
 import { fetchWithRetry } from "./fetchRetry";
+import { getResponseErrorMessage } from "./httpError";
 
 export type FetchSobolIndicesParams = {
   inputVars: string[];
@@ -35,7 +36,7 @@ export async function fetchSobolIndices(params: FetchSobolIndicesParams): Promis
   if (!response.ok) {
     // V23-style: reject (⊥ resolve) on non-OK so callers' .catch/try-catch can clear
     // any cached fetch-dedup state instead of treating the failure as a success.
-    throw new Error(`Error in Sobol' indices response: ${response.status}, ${response.statusText}`);
+    throw new Error(await getResponseErrorMessage(response));
   }
 
   return response.json();

--- a/node/src/utils/utils.test.ts
+++ b/node/src/utils/utils.test.ts
@@ -56,9 +56,7 @@ describe("fetchWithRetry", () => {
     const fetchMock = vi.fn(() => Promise.reject(new Error("Network error")));
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    await expect(fetchWithRetry("https://example.com/api", {}, 3, 100)).rejects.toThrow(
-      "fetchWithRetry: All retries failed and no error was captured.",
-    );
+    await expect(fetchWithRetry("https://example.com/api", {}, 3, 100)).rejects.toThrow("Network error");
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 

--- a/node/src/utils/utils.test.ts
+++ b/node/src/utils/utils.test.ts
@@ -61,6 +61,14 @@ describe("fetchWithRetry", () => {
     );
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
+
+  it("should return the final HTTP response after non-OK retries", async () => {
+    const response = { ok: false, status: 400, statusText: "Bad Request" };
+    const fetchMock = vi.fn(() => Promise.resolve(response));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(fetchWithRetry("https://example.com/api", {}, 1, 0)).resolves.toBe(response);
+  });
 });
 
 describe("Sampling Functions", () => {


### PR DESCRIPTION
## Summary
Surfaces backend failures in the UQ/SuMo plot components instead of silently rendering empty plots:

- Propagate backend errors through Sobol/correlation index fetches (new \`httpError\` util).
- Display backend error state in UQ plots, 1D/2D/surface/iso plots, and SuMo validation.
- Drop the incomplete CV-accuracy fetch path.

## Test plan
- Added unit tests: \`httpError\`, \`InsufficientDataWarning\`, sobol/correlation utils.
- No e2e/pixel-snapshot changes yet (to be followed up separately).

## Commits
- bc4aabd fix(node): surface backend errors in UQ plots
- 2de8a4b fix(node): display plot backend errors
- fc72aed fix(node): propagate sensitivity backend errors
- d83d5e0 fix(node): remove incomplete CV accuracy fetch

🤖 Generated with [opencode](https://opencode.ai)